### PR TITLE
Heading 컴포넌트 구현

### DIFF
--- a/src/components/common/Heading/Heading.stories.tsx
+++ b/src/components/common/Heading/Heading.stories.tsx
@@ -1,0 +1,53 @@
+import Heading from '@components/common/Heading/Heading';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+	title: 'common/Heading',
+	component: Heading,
+	parameters: {
+		layout: 'centered',
+		componentSubtitle:
+			'Heading는 크기, 색상을 받아 제목의 텍스트를 나타내는 공용 컴포넌트입니다.',
+	},
+	tags: ['autodocs'],
+	argTypes: {
+		size: {
+			control: {
+				type: 'radio',
+				options: ['xxl', 'xl', 'lg', 'md', 'sm', 'xs', 'xxs'],
+			},
+			description: 'Heading의 텍스트 크기를 지정합니다.',
+		},
+		color: {
+			control: {
+				type: 'select',
+			},
+			description: 'Heading의 텍스트 색상을 지정합니다.',
+			defaultValue: 'primary',
+		},
+		children: {
+			control: { type: 'text' },
+			description: 'Heading에 표시할 텍스트를 입력합니다.',
+		},
+	},
+} satisfies Meta<typeof Heading>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const XXL: Story = {
+	args: {
+		size: 'xxl',
+		children: 'Heading 컴포넌트',
+		color: 'primary',
+	},
+};
+
+export const MD: Story = {
+	args: {
+		size: 'md',
+		children: 'Heading 컴포넌트',
+		color: 'info',
+	},
+};

--- a/src/components/common/Heading/Heading.styled.ts
+++ b/src/components/common/Heading/Heading.styled.ts
@@ -1,0 +1,8 @@
+import { styled } from 'styled-components';
+import type { HeadingProps } from './Heading';
+
+export const HeadingWrapper = styled.h1<HeadingProps>`
+	font-size: ${(props) => props.theme.typography.fontSize.header[props.size]};
+	font-weight: ${(props) => props.theme.typography.fontWeight.semiBold};
+	color: ${(props) => props.color && props.theme.color.text[props.color]};
+`;

--- a/src/components/common/Heading/Heading.tsx
+++ b/src/components/common/Heading/Heading.tsx
@@ -1,0 +1,33 @@
+import type { PropsWithChildren } from 'react';
+import type { headingSize } from '@type/size';
+import type { textColor } from '@type/tokens';
+import * as S from './Heading.styled';
+
+export interface HeadingProps {
+	size: headingSize;
+	color?: textColor;
+	children: string;
+}
+
+const TAG_BY_SIZE = {
+	xxl: 'h1',
+	xl: 'h2',
+	lg: 'h3',
+	md: 'h4',
+	sm: 'h5',
+	xs: 'h6',
+	xxs: 'h6',
+} as const;
+
+const Heading = (props: PropsWithChildren<HeadingProps>) => {
+	const { size, color = 'primary', children, ...attributes } = props;
+	const headingTag = TAG_BY_SIZE[size];
+
+	return (
+		<S.HeadingWrapper as={headingTag} size={size} color={color} {...attributes}>
+			{children}
+		</S.HeadingWrapper>
+	);
+};
+
+export default Heading;

--- a/src/styles/tokens/typography.ts
+++ b/src/styles/tokens/typography.ts
@@ -6,7 +6,7 @@ const fontSize = {
 		md: '28px',
 		sm: '24px',
 		xs: '20px',
-		xss: '18px',
+		xxs: '18px',
 	},
 	body: {
 		lg: '16px',


### PR DESCRIPTION
## 📌 관련 이슈

- closed : https://github.com/98OO/colla-frontend/issues/7

## ✨ PR 세부 내용

- 크기, 색상을 받아 제목의 텍스트를 나타내는 공용 Heading 컴포넌트 구현
- 사용자로부터 전달받은 크기에 따라 태그가 선택되도록 구현
- typography의 fontSize 오타 수정 xss -> xxs
- Heading 컴포넌트 스토리 작성
