### PR TITLE
Entry 페이지 구현

### DIFF
--- a/src/apis/teamspace/getTeamSpaceInformation.ts
+++ b/src/apis/teamspace/getTeamSpaceInformation.ts
@@ -3,7 +3,7 @@ import { END_POINTS } from '@constants/api';
 
 const getTeamSpaceInformation = async (teamCode: string) => {
 	const response = await axiosInstance.get(
-		`${END_POINTS.PARTICIPATETEAMSPACE}?code=${teamCode}`
+		`${END_POINTS.TEAMSPACE}?code=${teamCode}`
 	);
 
 	return response.data.content;

--- a/src/apis/teamspace/getTeamSpaceInformation.ts
+++ b/src/apis/teamspace/getTeamSpaceInformation.ts
@@ -1,0 +1,12 @@
+import { axiosInstance } from '@apis/axiosInstance';
+import { END_POINTS } from '@constants/api';
+
+const getTeamSpaceInformation = async (teamCode: string) => {
+	const response = await axiosInstance.get(
+		`${END_POINTS.PARTICIPATETEAMSPACE}?code=${teamCode}`
+	);
+
+	return response.data.content;
+};
+
+export default getTeamSpaceInformation;

--- a/src/apis/teamspace/postCreateTeamSpace.ts
+++ b/src/apis/teamspace/postCreateTeamSpace.ts
@@ -1,0 +1,12 @@
+import { axiosInstance } from '@apis/axiosInstance';
+import { END_POINTS } from '@constants/api';
+
+const postCreateTeamSpace = async (teamName: string) => {
+	const response = await axiosInstance.post(`${END_POINTS.CREATETEAMSPACE}`, {
+		teamspaceName: teamName,
+	});
+
+	return response.data.content.teamspaceId;
+};
+
+export default postCreateTeamSpace;

--- a/src/apis/teamspace/postCreateTeamSpace.ts
+++ b/src/apis/teamspace/postCreateTeamSpace.ts
@@ -2,7 +2,7 @@ import { axiosInstance } from '@apis/axiosInstance';
 import { END_POINTS } from '@constants/api';
 
 const postCreateTeamSpace = async (teamName: string) => {
-	const response = await axiosInstance.post(`${END_POINTS.CREATETEAMSPACE}`, {
+	const response = await axiosInstance.post(`${END_POINTS.TEAMSPACE}`, {
 		teamspaceName: teamName,
 	});
 

--- a/src/apis/teamspace/postParticipateTeamSpace.ts
+++ b/src/apis/teamspace/postParticipateTeamSpace.ts
@@ -1,0 +1,16 @@
+import { axiosInstance } from '@apis/axiosInstance';
+import { END_POINTS } from '@constants/api';
+
+const postParticipateTeamSpace = async (
+	teamSpaceId: string,
+	teamCode: string
+) => {
+	await axiosInstance.post(
+		`${END_POINTS.PARTICIPATETEAMSPACE}/${teamSpaceId}/users`,
+		{
+			inviteCode: teamCode,
+		}
+	);
+};
+
+export default postParticipateTeamSpace;

--- a/src/apis/teamspace/postParticipateTeamSpace.ts
+++ b/src/apis/teamspace/postParticipateTeamSpace.ts
@@ -5,12 +5,9 @@ const postParticipateTeamSpace = async (
 	teamSpaceId: string,
 	teamCode: string
 ) => {
-	await axiosInstance.post(
-		`${END_POINTS.PARTICIPATETEAMSPACE}/${teamSpaceId}/users`,
-		{
-			inviteCode: teamCode,
-		}
-	);
+	await axiosInstance.post(`${END_POINTS.TEAMSPACE}/${teamSpaceId}/users`, {
+		inviteCode: teamCode,
+	});
 };
 
 export default postParticipateTeamSpace;

--- a/src/apis/user/getUserStatus.ts
+++ b/src/apis/user/getUserStatus.ts
@@ -1,0 +1,11 @@
+import { axiosInstance } from '@apis/axiosInstance';
+import { END_POINTS } from '@constants/api';
+import type { UserInformation } from '@type/user';
+
+const getUserStatus = async (): Promise<UserInformation> => {
+	const response = await axiosInstance.get(`${END_POINTS.USERSTATUS}`, {});
+
+	return response.data.content;
+};
+
+export default getUserStatus;

--- a/src/apis/user/postUserLastSeen.ts
+++ b/src/apis/user/postUserLastSeen.ts
@@ -1,0 +1,10 @@
+import { axiosInstance } from '@apis/axiosInstance';
+import { END_POINTS } from '@constants/api';
+
+const postUserLastSeen = async (teamspaceId: number) => {
+	await axiosInstance.post(`${END_POINTS.USERLASTSEEN}`, {
+		teamspaceId,
+	});
+};
+
+export default postUserLastSeen;

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -11,6 +11,9 @@ export const END_POINTS = {
 	AUTHMAILSEND: 'auth/mail/send',
 	AUTHMAILVERIFICATION: 'auth/mail/verification',
 	AUTHREGISTER: 'auth/register',
+	USERSTATUS: 'users/status',
+	USERLASTSEEN: 'users/last-seen',
+	TEAMSPACE: 'teamspaces',
 } as const;
 
 export const AUTH_ERROR_CODE = {

--- a/src/hooks/queries/useCreateTeamSpaceMutation.ts
+++ b/src/hooks/queries/useCreateTeamSpaceMutation.ts
@@ -1,0 +1,25 @@
+import { useNavigate } from 'react-router-dom';
+import postCreateTeamSpace from '@apis/teamspace/postCreateTeamSpace';
+import postUserLastSeen from '@apis/user/postUserLastSeen';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { PATH } from '@constants/path';
+
+const useCreateTeamSpaceMutation = () => {
+	const navigate = useNavigate();
+	const queryClient = useQueryClient();
+
+	const postCreateTeamSpaceMutation = useMutation({
+		mutationFn: postCreateTeamSpace,
+		onSuccess: (teamspaceId) => {
+			postUserLastSeen(teamspaceId);
+			queryClient.invalidateQueries({ queryKey: ['userStatus'] });
+			navigate(PATH.FEED);
+		},
+		onError: (error) => {
+			throw error;
+		},
+	});
+
+	return { mutatePostCreateTeamSpace: postCreateTeamSpaceMutation.mutate };
+};
+export default useCreateTeamSpaceMutation;

--- a/src/hooks/queries/useLoginMutation.tsx
+++ b/src/hooks/queries/useLoginMutation.tsx
@@ -1,12 +1,10 @@
 import { useNavigate } from 'react-router-dom';
 import postLogin from '@apis/user/postLogin';
 import { useMutation } from '@tanstack/react-query';
-import useUserStore from '@stores/userStore';
 import { ACCESS_TOKEN } from '@constants/api';
 import { PATH } from '@constants/path';
 
 const useLoginMutation = () => {
-	const { userInfo, setUserInfo } = useUserStore();
 	const navigate = useNavigate();
 
 	const postLoginMutation = useMutation({
@@ -14,10 +12,6 @@ const useLoginMutation = () => {
 		onSuccess: (content) => {
 			localStorage.setItem(ACCESS_TOKEN, content.accessToken);
 			if (content.hasTeam) {
-				setUserInfo({
-					...userInfo!,
-					userId: content.userId,
-				});
 				navigate(PATH.FEED);
 			} else {
 				navigate(PATH.ENTRY);

--- a/src/hooks/queries/useLoginMutation.tsx
+++ b/src/hooks/queries/useLoginMutation.tsx
@@ -12,8 +12,8 @@ const useLoginMutation = () => {
 	const postLoginMutation = useMutation({
 		mutationFn: postLogin,
 		onSuccess: (content) => {
+			localStorage.setItem(ACCESS_TOKEN, content.accessToken);
 			if (content.hasTeam) {
-				localStorage.setItem(ACCESS_TOKEN, content.accessToken);
 				setUserInfo({
 					...userInfo!,
 					userId: content.userId,

--- a/src/hooks/queries/useParticipateTeamSpaceMutation.ts
+++ b/src/hooks/queries/useParticipateTeamSpaceMutation.ts
@@ -1,0 +1,31 @@
+import { useNavigate } from 'react-router-dom';
+import getTeamSpaceInformation from '@apis/teamspace/getTeamSpaceInformation';
+import postParticipateTeamSpace from '@apis/teamspace/postParticipateTeamSpace';
+import postUserLastSeen from '@apis/user/postUserLastSeen';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { PATH } from '@constants/path';
+
+const useParticipateTeamSpaceMutation = (teamCode: string) => {
+	const navigate = useNavigate();
+	const queryClient = useQueryClient();
+
+	const postParticipateTeamSpaceMutation = useMutation({
+		mutationFn: () => getTeamSpaceInformation(teamCode),
+		onSuccess: async (content) => {
+			if (!content.isParticipated) {
+				await postParticipateTeamSpace(content.teamspaceId, teamCode);
+			}
+			postUserLastSeen(content.teamspaceId);
+			queryClient.invalidateQueries({ queryKey: ['userStatus'] });
+			navigate(PATH.FEED);
+		},
+		onError: (error) => {
+			throw error;
+		},
+	});
+
+	return {
+		mutateParticipateTeamSpace: postParticipateTeamSpaceMutation.mutateAsync,
+	};
+};
+export default useParticipateTeamSpaceMutation;

--- a/src/hooks/queries/useUserStatusQuery.ts
+++ b/src/hooks/queries/useUserStatusQuery.ts
@@ -1,0 +1,16 @@
+import getUserStatus from '@apis/user/getUserStatus';
+import { useQuery } from '@tanstack/react-query';
+import type { UserInformation } from '@type/user';
+
+const useUserStatusQuery = () => {
+	const { data: userStatus } = useQuery<UserInformation>({
+		queryKey: ['userStatus'],
+		queryFn: getUserStatus,
+		gcTime: 60 * 60 * 60 * 1000,
+		staleTime: 60 * 60 * 60 * 1000,
+	});
+
+	return { userStatus };
+};
+
+export default useUserStatusQuery;

--- a/src/pages/EntryPage/EntryPage.styled.ts
+++ b/src/pages/EntryPage/EntryPage.styled.ts
@@ -21,3 +21,11 @@ export const InputWrapper = styled.div`
 		width: 100%;
 	}
 `;
+
+export const ImageWrapper = styled.div`
+	width: 100%;
+
+	img {
+		width: 274px;
+	}
+`;

--- a/src/pages/EntryPage/EntryPage.tsx
+++ b/src/pages/EntryPage/EntryPage.tsx
@@ -1,17 +1,27 @@
 import { useState, ChangeEvent } from 'react';
+import { useNavigate } from 'react-router-dom';
+import getTeamSpaceInformation from '@apis/teamspace/getTeamSpaceInformation';
+import postParticipateTeamSpace from '@apis/teamspace/postParticipateTeamSpace';
 import { Button } from '@components/common/Button/Button';
 import Flex from '@components/common/Flex/Flex';
 import Heading from '@components/common/Heading/Heading';
 import Input from '@components/common/Input/Input';
 import Text from '@components/common/Text/Text';
+import useCreateTeamSpaceMutation from '@hooks/queries/useCreateTeamSpaceMutation';
+import { AxiosError } from 'axios';
+import { HTTPError } from '@apis/HTTPError';
+import { PATH } from '@constants/path';
 import { teamCreation, teamParticipation } from '@assets/png';
 import * as S from './EntryPage.styled';
 
 const EntryPage = () => {
 	const [entryData, setEntryData] = useState({
 		teamName: '',
-		teamLink: '',
+		teamCode: '',
 	});
+	const [errorText, setErrorText] = useState('');
+	const navigate = useNavigate();
+	const { mutatePostCreateTeamSpace } = useCreateTeamSpaceMutation();
 
 	const handleChange = (
 		e: ChangeEvent<HTMLInputElement>,
@@ -22,6 +32,26 @@ const EntryPage = () => {
 			...entryData,
 			[fieldName]: value,
 		});
+	};
+
+	const handleCreateTeamSpace = () => {
+		mutatePostCreateTeamSpace(entryData.teamName);
+	};
+
+	const handleParticipateTeamSpace = async () => {
+		try {
+			const response = await getTeamSpaceInformation(entryData.teamCode);
+			if (!response.isParticipated) {
+				await postParticipateTeamSpace(
+					response.teamspaceId,
+					entryData.teamCode
+				);
+			}
+			navigate(PATH.FEED);
+		} catch (error) {
+			const httpError = error as AxiosError<HTTPError>;
+			setErrorText(httpError.message);
+		}
 	};
 
 	return (
@@ -43,7 +73,9 @@ const EntryPage = () => {
 							팀스페이스를 만들고 협업을 시작하세요
 						</Text>
 					</Flex>
-					<img alt='collaBear' src={teamCreation} />
+					<S.ImageWrapper>
+						<img alt='teamCreation' src={teamCreation} />
+					</S.ImageWrapper>
 					<S.InputWrapper>
 						<Text size='md' weight='medium'>
 							팀스페이스 이름
@@ -57,12 +89,16 @@ const EntryPage = () => {
 							onChange={(e) => handleChange(e, 'teamName')}
 						/>
 					</S.InputWrapper>
-					<Button
-						label='생성하기'
-						variant='primary'
-						size='lg'
-						onClick={() => {}}
-					/>
+					<Flex direction='column'>
+						<Flex height='28' align='center' />
+						<Button
+							label='생성하기'
+							variant='primary'
+							size='lg'
+							disabled={entryData.teamName.length < 2}
+							onClick={handleCreateTeamSpace}
+						/>
+					</Flex>
 				</S.EntryOptionContainer>
 				<S.EntryOptionContainer>
 					<Flex direction='column' gap='4'>
@@ -71,7 +107,9 @@ const EntryPage = () => {
 							초대링크를 입력하여 팀스페이스에 참가하세요
 						</Text>
 					</Flex>
-					<img alt='collaBear' src={teamParticipation} />
+					<S.ImageWrapper>
+						<img alt='teamParticipation' src={teamParticipation} />
+					</S.ImageWrapper>
 					<S.InputWrapper>
 						<Text size='md' weight='medium'>
 							초대링크
@@ -80,16 +118,24 @@ const EntryPage = () => {
 							size='lg'
 							placeholder='초대링크 입력'
 							isError={false}
-							value={entryData.teamLink}
-							onChange={(e) => handleChange(e, 'teamLink')}
+							value={entryData.teamCode}
+							onChange={(e) => handleChange(e, 'teamCode')}
 						/>
 					</S.InputWrapper>
-					<Button
-						label='참가하기'
-						variant='primary'
-						size='lg'
-						onClick={() => {}}
-					/>
+					<Flex direction='column'>
+						<Flex height='28' align='center'>
+							<Text size='md' weight='regular' color='danger'>
+								{errorText}
+							</Text>
+						</Flex>
+						<Button
+							label='참가하기'
+							variant='primary'
+							size='lg'
+							disabled={entryData.teamCode.length === 0}
+							onClick={handleParticipateTeamSpace}
+						/>
+					</Flex>
 				</S.EntryOptionContainer>
 			</Flex>
 		</Flex>

--- a/src/pages/EntryPage/EntryPage.tsx
+++ b/src/pages/EntryPage/EntryPage.tsx
@@ -1,16 +1,13 @@
 import { useState, ChangeEvent } from 'react';
-import { useNavigate } from 'react-router-dom';
-import getTeamSpaceInformation from '@apis/teamspace/getTeamSpaceInformation';
-import postParticipateTeamSpace from '@apis/teamspace/postParticipateTeamSpace';
 import { Button } from '@components/common/Button/Button';
 import Flex from '@components/common/Flex/Flex';
 import Heading from '@components/common/Heading/Heading';
 import Input from '@components/common/Input/Input';
 import Text from '@components/common/Text/Text';
 import useCreateTeamSpaceMutation from '@hooks/queries/useCreateTeamSpaceMutation';
+import useParticipateTeamSpaceMutation from '@hooks/queries/useParticipateTeamSpaceMutation';
 import { AxiosError } from 'axios';
 import { HTTPError } from '@apis/HTTPError';
-import { PATH } from '@constants/path';
 import { teamCreation, teamParticipation } from '@assets/png';
 import * as S from './EntryPage.styled';
 
@@ -20,8 +17,10 @@ const EntryPage = () => {
 		teamCode: '',
 	});
 	const [errorText, setErrorText] = useState('');
-	const navigate = useNavigate();
 	const { mutatePostCreateTeamSpace } = useCreateTeamSpaceMutation();
+	const { mutateParticipateTeamSpace } = useParticipateTeamSpaceMutation(
+		entryData.teamCode
+	);
 
 	const handleChange = (
 		e: ChangeEvent<HTMLInputElement>,
@@ -40,14 +39,7 @@ const EntryPage = () => {
 
 	const handleParticipateTeamSpace = async () => {
 		try {
-			const response = await getTeamSpaceInformation(entryData.teamCode);
-			if (!response.isParticipated) {
-				await postParticipateTeamSpace(
-					response.teamspaceId,
-					entryData.teamCode
-				);
-			}
-			navigate(PATH.FEED);
+			await mutateParticipateTeamSpace();
 		} catch (error) {
 			const httpError = error as AxiosError<HTTPError>;
 			setErrorText(httpError.message);

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,3 +1,26 @@
 export interface AccessToken {
 	accessToken: string;
 }
+
+interface UserProfile {
+	userId: number;
+	username: string;
+	profileImageUrl: string;
+	email: string;
+	emailSubscription: boolean;
+	commentNotification: string;
+	lastSeenTeamspaceId: number;
+}
+
+interface ParticipatedTeamspace {
+	teamspaceId: number;
+	name: string;
+	profileImageUrl: string;
+	teamspaceRole: string;
+	numOfParticipant: number;
+}
+
+export interface UserInformation {
+	profile: UserProfile;
+	participatedTeamspaces: ParticipatedTeamspace[];
+}


### PR DESCRIPTION
## 📌 관련 이슈

- closed: https://github.com/98OO/colla-frontend/issues/37

## ✨ PR 세부 내용

- 로그인 성공에 대한 accessToken을 저장하는 코드 위치 수정
- 사용자 정보 type 추가 (사용자 프로필 및 팀 정보)
- 사용자 정보를 받아오는 query 구현
- 팀 스페이스 생성 및 초대 코드를 통해 참가하는 Entry 페이지 구현
- 팀 스페이스 생성, 조회, 참가에 대한 API Endpoint 추가 및 함수 구현 
- 팀 스페이스 생성 및 참가 이후 최근 접근 팀 스페이스 기록 함수 구현

## 📸 스크린샷(선택)

![팀 스페이스 참가 및 생성](https://github.com/98OO/colla-frontend/assets/127086869/e291d564-ca2d-4220-a4ca-ea777dbbfae0)
![팀 스페이스 참가 에러](https://github.com/98OO/colla-frontend/assets/127086869/1b3668e0-65d8-4020-91a6-e18363339bdc)

## ✅ 리뷰 요구사항(선택)

- Entry 페이지 UI 확인 후 수정사항 말씀해 주시면 추후 반영하겠습니다.