### PR TITLE
에러 핸들링을 위한 공통 Mutation 훅과 ErrorBoundary 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
 				"msw": "^1.3.3",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
+				"react-error-boundary": "^4.0.13",
 				"react-router-dom": "^6.22.3",
 				"styled-components": "^6.1.8",
 				"styled-reset": "^4.5.2",
@@ -14668,6 +14669,17 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
 			"integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
 			"dev": true
+		},
+		"node_modules/react-error-boundary": {
+			"version": "4.0.13",
+			"resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.13.tgz",
+			"integrity": "sha512-b6PwbdSv8XeOSYvjt8LpgpKrZ0yGdtZokYwkwV2wlcZbxgopHX/hgPl5VgpnoVOWd868n1hktM8Qm4b+02MiLQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.12.5"
+			},
+			"peerDependencies": {
+				"react": ">=16.13.1"
+			}
 		},
 		"node_modules/react-is": {
 			"version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"msw": "^1.3.3",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
+		"react-error-boundary": "^4.0.13",
 		"react-router-dom": "^6.22.3",
 		"styled-components": "^6.1.8",
 		"styled-reset": "^4.5.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { Outlet, useLocation } from 'react-router-dom';
 import Flex from '@components/common/Flex/Flex';
+import GlobalErrorBoundary from '@components/common/GlobalErrorBoundary/GlobalErrorBoundary';
 import GNB from '@components/common/GNB/GNB';
 import SNBFull from '@components/common/SideNavigationBar/SNBFull/SNBFull';
 import SNBIcon from '@components/common/SideNavigationBar/SNBIcon/SNBIcon';
@@ -19,18 +20,20 @@ function App() {
 	].some((path) => location.pathname.includes(path));
 
 	return (
-		<Flex direction='column'>
-			{isSideNavigationBarVisible && <GNB />}
-			<Flex>
-				{isSideNavigationBarVisible &&
-					(isMobileView ? <SNBIcon /> : <SNBFull />)}
-				{isChatPage && <SNBIcon />}
-				<main>
-					<Outlet />
-				</main>
-				<ToastContainer />
+		<GlobalErrorBoundary>
+			<Flex direction='column'>
+				{isSideNavigationBarVisible && <GNB />}
+				<Flex>
+					{isSideNavigationBarVisible &&
+						(isMobileView ? <SNBIcon /> : <SNBFull />)}
+					{isChatPage && <SNBIcon />}
+					<main>
+						<Outlet />
+					</main>
+					<ToastContainer />
+				</Flex>
 			</Flex>
-		</Flex>
+		</GlobalErrorBoundary>
 	);
 }
 

--- a/src/components/common/Error/Error.tsx
+++ b/src/components/common/Error/Error.tsx
@@ -6,18 +6,17 @@ import { HTTP_STATUS_CODE, HTTP_ERROR_MESSAGE } from '@constants/api';
 import { signPost } from '@assets/png';
 import * as S from './Error.styled';
 
-type ErrorCode = typeof HTTP_STATUS_CODE.NOT_FOUND;
-
 interface ErrorProps {
-	errorCode: ErrorCode;
+	errorCode: number;
 	resetError: () => void;
 }
 
-const Error = ({
-	errorCode = HTTP_STATUS_CODE.NOT_FOUND,
-	resetError,
-}: ErrorProps) => {
-	const errorMessage = HTTP_ERROR_MESSAGE[errorCode];
+const Error = ({ errorCode, resetError }: ErrorProps) => {
+	const errorMessage =
+		errorCode === HTTP_STATUS_CODE.NOT_FOUND ||
+		errorCode === HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR
+			? HTTP_ERROR_MESSAGE[errorCode]
+			: HTTP_ERROR_MESSAGE.DEFAULT;
 
 	return (
 		<Flex gap='72' align='center'>

--- a/src/components/common/ErrorFallback/ErrorFallback.tsx
+++ b/src/components/common/ErrorFallback/ErrorFallback.tsx
@@ -1,0 +1,21 @@
+import { FallbackProps } from 'react-error-boundary';
+import { useNavigate } from 'react-router-dom';
+import Error from '@components/common/Error/Error';
+import { HTTP_STATUS_CODE } from '@constants/api';
+import { PATH } from '@constants/path';
+
+export const ErrorFallback = ({ error, resetErrorBoundary }: FallbackProps) => {
+	const navigate = useNavigate();
+	const { status } = error;
+
+	const handleServerError = () => {
+		resetErrorBoundary();
+		navigate(PATH.ROOT);
+	};
+
+	if (status === HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR) {
+		return <Error errorCode={status} resetError={handleServerError} />;
+	}
+
+	return <Error errorCode={status} resetError={resetErrorBoundary} />;
+};

--- a/src/components/common/GlobalErrorBoundary/GlobalErrorBoundary.tsx
+++ b/src/components/common/GlobalErrorBoundary/GlobalErrorBoundary.tsx
@@ -1,0 +1,38 @@
+/* eslint-disable no-console */
+import { ErrorBoundary } from 'react-error-boundary';
+import { ErrorFallback } from '@components/common/ErrorFallback/ErrorFallback';
+import { useQueryErrorResetBoundary } from '@tanstack/react-query';
+import { HTTPError } from '@apis/HTTPError';
+
+interface Props {
+	children: React.ReactNode;
+}
+
+const logError = (error: Error | HTTPError) => {
+	if (error instanceof HTTPError) {
+		const { status, code, message, content } = error;
+		console.groupCollapsed(`HTTPError: ${status} ${message}`);
+		console.log('Status:', status);
+		console.log('Code:', code);
+		console.log('Message:', message);
+		console.log('Content:', content);
+		console.groupEnd();
+	} else {
+		console.error(error);
+	}
+};
+
+const GlobalErrorBoundary = ({ children }: Props) => {
+	const { reset } = useQueryErrorResetBoundary();
+
+	return (
+		<ErrorBoundary
+			onError={logError}
+			FallbackComponent={ErrorFallback}
+			onReset={reset}>
+			{children}
+		</ErrorBoundary>
+	);
+};
+
+export default GlobalErrorBoundary;

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -59,6 +59,25 @@ export const HTTP_ERROR_MESSAGE = {
 		},
 		BUTTON: '홈으로 이동',
 	},
+	[HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR]: {
+		HEADING: '앗, 뭔가 문제가 생겼어요..',
+		BODY: {
+			firstLine: '서비스와 연결할 수 없습니다',
+			secondLine: '문제를 해결하기 위해 열심히 노력하고 있습니다',
+			thridLine: '잠시 후 다시 확인해주세요',
+		},
+		BUTTON: '홈으로 이동',
+	},
+	DEFAULT: {
+		HEADING: '앗, 뭔가 문제가 생겼어요..',
+		BODY: {
+			firstLine: '일시적인 오류로 현재 요청사항을 처리하는데 실패했습니다',
+			secondLine: '잠시 후 다시 한 번 시도해주세요',
+			thridLine:
+				'지속적으로 발생할 경우 새로 고침하거나 다른 페이지로 이동해주세요',
+		},
+		BUTTON: '다시 시도',
+	},
 };
 
 export const AUTH_API_URL = {

--- a/src/hooks/queries/common/queryClient.ts
+++ b/src/hooks/queries/common/queryClient.ts
@@ -1,0 +1,9 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+	defaultOptions: {
+		queries: {
+			throwOnError: true,
+		},
+	},
+});

--- a/src/hooks/queries/common/useMutation.ts
+++ b/src/hooks/queries/common/useMutation.ts
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+import { HTTPError } from '@apis/HTTPError';
+
+type FetchFn<T> = () => Promise<T>;
+type Props<T> = {
+	onSuccess?: (data: T) => void;
+	onError?: (error: Error) => void;
+};
+
+export const useMutation = <T>({ onSuccess, onError }: Props<T>) => {
+	const [error, setError] = useState<HTTPError | null>(null);
+
+	const mutate = async (fetchFn: FetchFn<T>) => {
+		try {
+			const data = await fetchFn();
+			if (onSuccess) onSuccess(data);
+		} catch (err) {
+			if (err instanceof HTTPError) {
+				if (!onError) setError(err);
+				else onError(err);
+			}
+		}
+	};
+
+	if (error) throw error;
+
+	return { mutate };
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { queryClient } from '@hooks/queries/common/queryClient';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { ThemeProvider } from 'styled-components';
 import { worker } from '@mocks/browser';
@@ -12,8 +13,6 @@ import './index.css';
 if (process.env.NODE_ENV === 'development') {
 	worker.start();
 }
-
-const queryClient = new QueryClient();
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
 	<React.StrictMode>


### PR DESCRIPTION
## 📌 관련 이슈

- closed : https://github.com/98OO/colla-frontend/issues/47

## ✨ PR 세부 내용
- ErrorBoundary의 함수형 사용을 위한 react-error-boudnary 추가
- 서버 및 디폴트 Error Message 추가
- 에러 핸들링을 위한 GlobalErrorBoundary 및 ErrorFallback 추가
- 에러 전파를 위한 queryClient의 throwOnError 값 변경
- 비동기 작업 및 에러 처리를 위한 커스텀 useMutation 훅 추가

## ✅ 리뷰 요구사항


![image](https://github.com/98OO/colla-frontend/assets/98178673/a0e59192-f13a-4e48-a257-b51cebf1d2c4)

공통 응답 형식의 HTTPError 확인을 보다 간편하게 확인하기 위해 위 형식으로 에러를 출력합니다!
