### PR TITLE
파일 업로드를 위한 useFileUpload 커스텀 훅 구현

### DIFF
--- a/src/apis/common/postFileUploadUrls.ts
+++ b/src/apis/common/postFileUploadUrls.ts
@@ -1,0 +1,27 @@
+import { axiosInstance } from '@apis/axiosInstance';
+import { END_POINTS } from '@constants/api';
+
+export interface UrlRequest {
+	domainType: 'USER' | 'TEAMSPACE';
+	teamspaceId?: number;
+	originalAttachmentName: string;
+}
+
+export interface Urls {
+	presignedUrl: string;
+	attachmentUrl: string;
+}
+
+export interface UrlResponse {
+	fileUploadUrlsDtos: Urls[];
+}
+
+export const postFileUploadUrls = async (
+	fileUploadDtos: UrlRequest[]
+): Promise<UrlResponse> => {
+	const response = await axiosInstance.post(END_POINTS.PRESIGNED, {
+		fileUploadDtos,
+	});
+
+	return response.data.content;
+};

--- a/src/apis/common/putFileUpload.ts
+++ b/src/apis/common/putFileUpload.ts
@@ -1,0 +1,24 @@
+import { axiosInstance } from '@apis/axiosInstance';
+
+export interface FileUploadInfos {
+	presignedURL: string;
+	file: File;
+	contentType: string;
+}
+
+const putFileUpload = async ({
+	presignedURL,
+	file,
+	contentType,
+}: FileUploadInfos) => {
+	const response = await axiosInstance.put(presignedURL, file, {
+		headers: {
+			'Content-Type': contentType,
+		},
+		authRequired: false,
+	});
+
+	return response.data.content;
+};
+
+export default putFileUpload;

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -15,6 +15,7 @@ export const END_POINTS = {
 	USERSTATUS: 'users/status',
 	USERLASTSEEN: 'users/last-seen',
 	TEAMSPACE: 'teamspaces',
+	PRESIGNED: 'presigned',
 } as const;
 
 export const AUTH_ERROR_CODE = {

--- a/src/constants/size.ts
+++ b/src/constants/size.ts
@@ -1,0 +1,1 @@
+export const FILE_SIZE_LIMIT = 100 * 1024 * 1024;

--- a/src/hooks/common/useFileUpload.ts
+++ b/src/hooks/common/useFileUpload.ts
@@ -1,0 +1,58 @@
+import useFileUploadMutation from '@hooks/queries/common/useFileUploadMutation';
+import useFileUploadUrlsMutation from '@hooks/queries/common/useFileUploadUrlsMutation';
+import { FILE_SIZE_LIMIT } from '@constants/size';
+import type { UrlRequest } from '@apis/common/postFileUploadUrls';
+
+const useFileUpload = () => {
+	const { mutateFileUploadUrls } = useFileUploadUrlsMutation();
+	const { mutateFileUpload } = useFileUploadMutation();
+
+	const uploadFiles = async (
+		files: FileList,
+		domainType: 'USER' | 'TEAMSPACE',
+		teamspaceId?: number
+	) => {
+		const fileUploadDtos: UrlRequest[] = Array.from(files).map((file) => ({
+			domainType,
+			teamspaceId,
+			originalAttachmentName: file.name,
+		}));
+
+		const response = await mutateFileUploadUrls(fileUploadDtos);
+
+		if (response) {
+			const { fileUploadUrlsDtos } = response;
+
+			const fileUploadInfos = fileUploadUrlsDtos.map(
+				({ presignedUrl }, index) => ({
+					presignedURL: presignedUrl,
+					file: files[index],
+					contentType: files[index].type,
+				})
+			);
+
+			try {
+				await mutateFileUpload(fileUploadInfos);
+
+				const attachmentUrls = fileUploadUrlsDtos.map(
+					({ attachmentUrl }) => attachmentUrl
+				);
+				return attachmentUrls;
+			} catch (error) {
+				return null;
+			}
+		}
+
+		return null;
+	};
+
+	const isFileSizeExceedLimit = (file: File): boolean => {
+		const fileSizeInBytes = file.size;
+		const maxFileSizeInBytes = FILE_SIZE_LIMIT;
+		return fileSizeInBytes > maxFileSizeInBytes;
+	};
+
+	return { uploadFiles, isFileSizeExceedLimit };
+};
+
+export default useFileUpload;

--- a/src/hooks/queries/common/useFileUploadMutation.ts
+++ b/src/hooks/queries/common/useFileUploadMutation.ts
@@ -1,0 +1,33 @@
+import { useErrorBoundary } from 'react-error-boundary';
+import putFileUpload from '@apis/common/putFileUpload';
+import { useMutation } from '@hooks/queries/common/useMutation';
+import useToastStore from '@stores/toastStore';
+import { HTTPError } from '@apis/HTTPError';
+import type { FileUploadInfos } from '@apis/common/putFileUpload';
+
+const useFileUploadMutation = () => {
+	const { makeToast } = useToastStore();
+	const { showBoundary } = useErrorBoundary();
+
+	const handleFileUploadError = (error: Error) => {
+		if (error instanceof HTTPError) {
+			makeToast('파일 업로드 중 오류가 발생했습니다', 'Warning');
+		} else showBoundary(error);
+	};
+
+	const { mutate } = useMutation({
+		onSuccess: () => {},
+		onError: handleFileUploadError,
+	});
+
+	const mutateFileUpload = async (fileUploadInfos: FileUploadInfos[]) => {
+		const uploadPromises = fileUploadInfos.map((fileUploadInfo) => {
+			return mutate(() => putFileUpload(fileUploadInfo));
+		});
+		await Promise.all(uploadPromises);
+	};
+
+	return { mutateFileUpload };
+};
+
+export default useFileUploadMutation;

--- a/src/hooks/queries/common/useFileUploadUrlsMutation.ts
+++ b/src/hooks/queries/common/useFileUploadUrlsMutation.ts
@@ -1,0 +1,33 @@
+import { useErrorBoundary } from 'react-error-boundary';
+import {
+	postFileUploadUrls,
+	UrlRequest,
+	UrlResponse,
+} from '@apis/common/postFileUploadUrls';
+import { useMutation } from '@hooks/queries/common/useMutation';
+import useToastStore from '@stores/toastStore';
+import { HTTPError } from '@apis/HTTPError';
+
+const useFileUploadUrlsMutation = () => {
+	const { makeToast } = useToastStore();
+	const { showBoundary } = useErrorBoundary();
+
+	const handlePresignedURLError = (error: Error) => {
+		if (error instanceof HTTPError) {
+			makeToast('파일 업로드 중 오류가 발생했습니다', 'Warning');
+		} else showBoundary(error);
+	};
+
+	const { mutate } = useMutation<UrlResponse>({
+		onSuccess: () => {},
+		onError: handlePresignedURLError,
+	});
+
+	const mutateFileUploadUrls = async (fileUploadDtos: UrlRequest[]) => {
+		return mutate(() => postFileUploadUrls(fileUploadDtos));
+	};
+
+	return { mutateFileUploadUrls };
+};
+
+export default useFileUploadUrlsMutation;

--- a/src/hooks/queries/common/useMutation.ts
+++ b/src/hooks/queries/common/useMutation.ts
@@ -10,10 +10,12 @@ type Props<T> = {
 export const useMutation = <T>({ onSuccess, onError }: Props<T>) => {
 	const [error, setError] = useState<HTTPError | null>(null);
 
+	// eslint-disable-next-line consistent-return
 	const mutate = async (fetchFn: FetchFn<T>) => {
 		try {
 			const data = await fetchFn();
 			if (onSuccess) onSuccess(data);
+			return data;
 		} catch (err) {
 			if (err instanceof HTTPError) {
 				if (!onError) setError(err);


### PR DESCRIPTION
## 📌 관련 이슈

- closed : https://github.com/98OO/colla-frontend/issues/68

## ✨ PR 세부 내용
- PresignedUrl 및 attachmentUrl 발급 mutation
- 발급받은 PresignedUrl을 사용해 S3 서버에 파일 저장 mutation
- 파일 업로드를 위한 useFileUpload 커스텀 훅 구현

## ✅ 리뷰 요구사항
- 훅 사용 시 domainType이 TEAMSPACE인 경우에만 teamspaceId를 작성해주세요
- 파일마다 100MB 제한이 걸려있어 유의해주세요
- 파일 용량 확인 시 isFileSizeExceedLimit 함수를 사용해주세요
