### PR TITLE
GNB 메뉴 토글 기능 추가

### DIFF
--- a/src/components/common/Avatar/Avatar.tsx
+++ b/src/components/common/Avatar/Avatar.tsx
@@ -8,6 +8,7 @@ export interface AvatarProps {
 	initial: string;
 	size: AvatarSize;
 	shape: 'circle' | 'rect';
+	onClick?: React.MouseEventHandler<HTMLDivElement>;
 }
 
 const sizeMap = {
@@ -35,11 +36,15 @@ const textMap = {
 };
 
 const Avatar = (props: AvatarProps) => {
-	const { profile, initial, size, shape } = props;
+	const { profile, initial, size, shape, onClick } = props;
 	const avatarText = size === 'xl' || size === 'lg' ? 'heading' : 'text';
 
 	return (
-		<S.AvatarContainer profile={profile} size={size} shape={shape}>
+		<S.AvatarContainer
+			profile={profile}
+			size={size}
+			shape={shape}
+			onClick={onClick}>
 			{profile ? (
 				<img src={profile} alt='profile' />
 			) : (

--- a/src/components/common/GNB/GNB.tsx
+++ b/src/components/common/GNB/GNB.tsx
@@ -1,8 +1,15 @@
+import { useLayoutEffect, useRef, useState } from 'react';
 import Avatar from '@components/common/Avatar/Avatar';
 import { Button } from '@components/common/Button/Button';
+import GNBProfile from '@components/common/GNB/GNBMenu/GNBProfile/GNBProfile';
+import GNBTeamInfo from '@components/common/GNB/GNBMenu/GNBTeamInfo/GNBTeamInfo';
+import GNBTeamSpace from '@components/common/GNB/GNBMenu/GNBTeamSpace/GNBTeamSpace';
 import Heading from '@components/common/Heading/Heading';
+import Icon from '@components/common/Icon/Icon';
 import IconButton from '@components/common/IconButton/IconButton';
+import useMenu from '@hooks/common/useMenu';
 import useUserStatusQuery from '@hooks/queries/useUserStatusQuery';
+import { GNB_PROFILE_WIDTH, GNB_TEAM_INFO_WIDTH } from '@styles/layout';
 import * as S from './GNB.styled';
 
 const GNB = () => {
@@ -12,11 +19,32 @@ const GNB = () => {
 		(team) => team.teamspaceId === lastSeenTeamspaceId
 	);
 
+	const { toggleMenu: handleTeamSpace, showMenu: showTeamSpace } = useMenu();
+	const { toggleMenu: handleTeamInfo, showMenu: showTeamInfo } = useMenu();
+	const { toggleMenu: handleProfile, showMenu: showProfile } = useMenu();
+	const baseRef = useRef<HTMLDivElement>(null);
+
+	const [position, setPosition] = useState(0);
+
+	const updatePosition = () => {
+		if (baseRef.current) {
+			setPosition(baseRef.current.offsetWidth);
+		}
+	};
+
+	useLayoutEffect(() => {
+		updatePosition();
+		window.addEventListener('resize', updatePosition);
+		return () => {
+			window.removeEventListener('resize', updatePosition);
+		};
+	}, [baseRef.current?.offsetWidth]);
+
 	return (
-		<S.GNBContainer>
+		<S.GNBContainer ref={baseRef}>
 			{userStatus && lastSeenTeam && (
 				<>
-					<S.LeftContainer onClick={() => ''}>
+					<S.LeftContainer onClick={handleTeamSpace}>
 						<Avatar
 							profile={lastSeenTeam.profileImageUrl}
 							initial={lastSeenTeam.name}
@@ -24,8 +52,12 @@ const GNB = () => {
 							shape='rect'
 						/>
 						<Heading size='md'>{lastSeenTeam.name}</Heading>
-						<IconButton icon='Updown' ariaLabel='Updown' onClick={() => ''} />
+						<Icon name='Updown' />
 					</S.LeftContainer>
+					{showTeamSpace(baseRef, <GNBTeamSpace />, {
+						top: 70,
+						left: 10,
+					})}
 					<S.RightContainer>
 						<IconButton
 							icon='Bell'
@@ -40,14 +72,23 @@ const GNB = () => {
 								variant='secondary'
 								size='sm'
 								leadingIcon='User'
-								onClick={() => ''}
+								onClick={handleTeamInfo}
 							/>
+							{showTeamInfo(baseRef, <GNBTeamInfo />, {
+								top: 70,
+								left: position - GNB_TEAM_INFO_WIDTH - 10,
+							})}
 							<Avatar
 								profile={userStatus.profile.profileImageUrl}
 								initial={userStatus.profile.username}
 								size='md'
 								shape='circle'
+								onClick={handleProfile}
 							/>
+							{showProfile(baseRef, <GNBProfile />, {
+								top: 70,
+								left: position - GNB_PROFILE_WIDTH - 10,
+							})}
 						</S.ProfileContainer>
 					</S.RightContainer>
 				</>

--- a/src/components/common/GNB/GNBMenu/GNBProfile/GNBProfile.styled.ts
+++ b/src/components/common/GNB/GNBMenu/GNBProfile/GNBProfile.styled.ts
@@ -1,10 +1,11 @@
 import styled from 'styled-components';
+import { GNB_PROFILE_WIDTH } from '@styles/layout';
 import theme from '@styles/theme';
 
 export const GNBProfileContainer = styled.div`
 	display: flex;
 	flex-direction: column;
-	width: 240px;
+	width: ${GNB_PROFILE_WIDTH}px;
 	height: 234px;
 
 	background-color: ${theme.color.bg.primary};

--- a/src/components/common/GNB/GNBMenu/GNBTeamInfo/GNBTeamInfo.styled.ts
+++ b/src/components/common/GNB/GNBMenu/GNBTeamInfo/GNBTeamInfo.styled.ts
@@ -1,11 +1,11 @@
 import styled from 'styled-components';
-import { MENU_HEIGHT } from '@styles/layout';
+import { MENU_HEIGHT, GNB_TEAM_INFO_WIDTH } from '@styles/layout';
 import theme from '@styles/theme';
 
 export const GNBTeamInfoContainer = styled.div`
 	display: flex;
 	flex-direction: column;
-	width: 320px;
+	width: ${GNB_TEAM_INFO_WIDTH}px;
 
 	background-color: ${theme.color.bg.primary};
 	border-radius: ${theme.units.radius.radius8};

--- a/src/components/common/IconButton/IconButton.styled.ts
+++ b/src/components/common/IconButton/IconButton.styled.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import theme from '@styles/theme';
 
 export const IconButtonWrapper = styled.button`
 	display: flex;
@@ -8,4 +9,9 @@ export const IconButtonWrapper = styled.button`
 	box-sizing: border-box;
 	border: none;
 	background-color: transparent;
+	padding: ${theme.units.spacing.space4};
+	border-radius: ${theme.units.radius.radius6};
+	&:hover {
+		background-color: ${theme.color.bg.iSecondaryHover};
+	}
 `;

--- a/src/hooks/common/useMenu.tsx
+++ b/src/hooks/common/useMenu.tsx
@@ -1,0 +1,62 @@
+import { ReactNode, RefObject, useState } from 'react';
+import useOutsideClick from '@hooks/common/useOutSideClick';
+import styled from 'styled-components';
+
+interface MenuPosition {
+	top?: number;
+	bottom?: number;
+	left?: number;
+	right?: number;
+}
+
+const MenuContainer = styled.div<MenuPosition>`
+	position: absolute;
+	top: ${(props) => `${props.top}px` ?? 'auto'};
+	bottom: ${(props) => `${props.bottom}px` ?? 'auto'};
+	left: ${(props) => `${props.left}px` ?? 'auto'};
+	right: ${(props) => `${props.right}px` ?? 'auto'};
+	z-index: ${(props) => props.theme.elevation.zIndex.MENU};
+`;
+
+const useMenu = () => {
+	const [isVisible, setIsVisible] = useState(false);
+
+	const toggleMenu = () => {
+		setIsVisible((prev) => !prev);
+	};
+
+	const ref = useOutsideClick({
+		onClickOutside: () => setIsVisible(false),
+	});
+
+	const showMenu = (
+		baseRef: RefObject<HTMLElement>,
+		menu: ReactNode,
+		menuPosition: MenuPosition
+	) => {
+		const baseElement = baseRef.current;
+		if (!baseElement) return null;
+
+		const baseRect = baseElement.getBoundingClientRect();
+		const { top, bottom, left, right } = baseRect;
+
+		const position: MenuPosition = {
+			top: (menuPosition.top ?? 0) + top,
+			bottom: (menuPosition.bottom ?? 0) + bottom,
+			left: (menuPosition.left ?? 0) + left,
+			right: (menuPosition.right ?? 0) + right,
+		};
+
+		return (
+			isVisible && (
+				<MenuContainer ref={ref} {...position}>
+					{menu}
+				</MenuContainer>
+			)
+		);
+	};
+
+	return { toggleMenu, showMenu };
+};
+
+export default useMenu;

--- a/src/hooks/common/useOutSideClick.ts
+++ b/src/hooks/common/useOutSideClick.ts
@@ -1,0 +1,31 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+interface UseOutsideClickProps {
+	onClickOutside: () => void;
+}
+
+const useOutsideClick = ({ onClickOutside }: UseOutsideClickProps) => {
+	const ref = useRef<HTMLDivElement | null>(null);
+
+	const handleClickOutside = useCallback(
+		(event: MouseEvent) => {
+			const inside = ref.current?.contains(event.target as Node);
+			if (ref.current && !inside) {
+				onClickOutside();
+			}
+		},
+		[onClickOutside, ref]
+	);
+
+	useEffect(() => {
+		document.addEventListener('mouseup', handleClickOutside);
+
+		return () => {
+			document.removeEventListener('mouseup', handleClickOutside);
+		};
+	}, [handleClickOutside]);
+
+	return ref;
+};
+
+export default useOutsideClick;

--- a/src/styles/layout.ts
+++ b/src/styles/layout.ts
@@ -1,1 +1,5 @@
 export const MENU_HEIGHT = '185px';
+
+export const GNB_TEAM_INFO_WIDTH = 320;
+
+export const GNB_PROFILE_WIDTH = 240;


### PR DESCRIPTION
## 📌 관련 이슈

- closed : https://github.com/98OO/colla-frontend/issues/81

## ✨ PR 세부 내용
- 메뉴 외부 영역 클릭 확인 및 추가 동작을 위한 useOutsideClick 훅 구현
- 메뉴 토글을 위한 useMenu 훅 구현
- 메뉴 토글을 위해 GNB 컴포넌트에 훅을 적용
    - GNB 컴포넌트를 기준으로 메뉴 컴포넌트의 위치를 조정
    - 메뉴 외부 영역을 클릭 시 메뉴 컴포넌트 토글
    - 레이아웃 변경 시 메뉴의 위치 업데이트
- IconButton 컴포넌트 스타일 추가

## 📸 스크린샷
![image](https://github.com/98OO/colla-frontend/assets/98178673/5f0fb34e-61ae-46ed-85cc-51f2ca723671)
![image](https://github.com/98OO/colla-frontend/assets/98178673/1e6c38fd-6e99-430d-9cb0-7b960499f1f0)
![image](https://github.com/98OO/colla-frontend/assets/98178673/f0a7eb3c-df10-48e3-b205-57220d408797)
