### PR TITLE
일반 피드 조회 임시 구현

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -65,6 +65,11 @@ module.exports = {
 						position: 'after',
 					},
 					{
+						pattern: '@utils/*',
+						group: 'internal',
+						position: 'after',
+					},
+					{
 						pattern: '@types/*',
 						group: 'internal',
 						position: 'after',

--- a/src/assets/svg/download.svg
+++ b/src/assets/svg/download.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M19.5 14.5V17.8333C19.5 18.2754 19.3244 18.6993 19.0118 19.0118C18.6993 19.3244 18.2754 19.5 17.8333 19.5H6.16667C5.72464 19.5 5.30072 19.3244 4.98816 19.0118C4.67559 18.6993 4.5 18.2754 4.5 17.8333V14.5" stroke="stroke" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.83301 10.3333L11.9997 14.5L16.1663 10.3333" stroke="stroke" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 14.5V4.5" stroke="stroke" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/svg/index.ts
+++ b/src/assets/svg/index.ts
@@ -29,3 +29,4 @@ export { ReactComponent as Profile } from './user.svg';
 export { ReactComponent as Image } from './image.svg';
 export { ReactComponent as File } from './file.svg';
 export { ReactComponent as Kebab } from './kebab.svg';
+export { ReactComponent as Download } from './download.svg';

--- a/src/components/Feed/Attachments/Attachments.styled.ts
+++ b/src/components/Feed/Attachments/Attachments.styled.ts
@@ -1,0 +1,11 @@
+import { styled } from 'styled-components';
+import theme from '@styles/theme';
+
+export const AttachmentWrapper = styled.div`
+	display: flex;
+	border: 1px solid ${theme.color.border.primary};
+	justify-content: space-between;
+	padding: ${theme.units.spacing.space12};
+	border-radius: ${theme.units.radius.radius8};
+	gap: ${theme.units.spacing.space32};
+`;

--- a/src/components/Feed/Attachments/Attachments.tsx
+++ b/src/components/Feed/Attachments/Attachments.tsx
@@ -1,0 +1,48 @@
+import IconButton from '@components/common/IconButton/IconButton';
+import Profile from '@components/common/Profile/Profile';
+import { getUnitFormattedSize } from '@utils/getUnitFormattedSize';
+import * as S from './Attachments.styled';
+
+interface Attachment {
+	id: number;
+	name: string;
+	fileUrl: string;
+	size: number;
+}
+
+interface AttachmentsProps {
+	attachment: Attachment;
+}
+
+const Attachments = ({ attachment }: AttachmentsProps) => {
+	const { name, fileUrl, size } = attachment;
+
+	const filterImageURL = (url: string) => {
+		const imageRegEx = /\.(jpg|jpeg|png|gif|bmp)$/i;
+		return imageRegEx.test(url) ? url : null;
+	};
+
+	return (
+		<S.AttachmentWrapper>
+			<Profile
+				profile={filterImageURL(fileUrl)}
+				initial={name.charAt(0)}
+				avatarSize='lg'
+				avatarShape='rect'
+				title={name}
+				titleSize='lg'
+				titleWeight='medium'
+				text={getUnitFormattedSize(size)}
+			/>
+			<IconButton
+				ariaLabel='download'
+				icon='Download'
+				color='primary'
+				size='md'
+				onClick={() => window.open(fileUrl, '_blank')}
+			/>
+		</S.AttachmentWrapper>
+	);
+};
+
+export default Attachments;

--- a/src/components/Feed/Comments/Comment.tsx
+++ b/src/components/Feed/Comments/Comment.tsx
@@ -1,0 +1,35 @@
+import Profile from '@components/common/Profile/Profile';
+
+interface Comment {
+	author: {
+		id: number;
+		profileImageUrl: string | null;
+		username: string;
+	};
+	content: string;
+	createdAt: string;
+}
+
+interface CommentsProps {
+	comment: Comment;
+}
+
+const Comment = ({ comment }: CommentsProps) => {
+	const { author, content, createdAt } = comment;
+	return (
+		<Profile
+			profile={author.profileImageUrl}
+			initial={author.username.charAt(0)}
+			avatarSize='lg'
+			avatarShape='rect'
+			title={author.username}
+			titleSize='lg'
+			titleWeight='medium'
+			subTitle={createdAt}
+			text={content}
+			trailingIcon='Kebab'
+		/>
+	);
+};
+
+export default Comment;

--- a/src/components/Feed/Feed.styled.ts
+++ b/src/components/Feed/Feed.styled.ts
@@ -4,9 +4,8 @@ import theme from '@styles/theme';
 export const FeedContainer = styled.div`
 	display: flex;
 	flex-direction: column;
-	gap: ${theme.units.spacing.space20};
+	gap: ${theme.units.spacing.space24};
 	width: 680px;
-	min-height: 720px;
 	padding: ${theme.units.spacing.space24};
 	border-radius: ${theme.units.radius.radius12};
 	box-shadow: ${theme.elevation.shadow.shadow8};
@@ -14,7 +13,26 @@ export const FeedContainer = styled.div`
 `;
 
 export const DetailWrapper = styled.div`
-	min-height: 400px;
+	padding: ${theme.units.spacing.space16} 0;
+	min-height: 50px;
+	max-height: 200px;
+	position: relative;
+	overflow: hidden;
+
+	&:after {
+		content: '';
+		position: absolute;
+		bottom: 0;
+		left: 0;
+		width: 100%;
+		height: calc(100% - 140px);
+		background: linear-gradient(
+			to bottom,
+			transparent,
+			${theme.color.bg.primary}
+		);
+		pointer-events: none;
+	}
 `;
 
 export const CommentContainer = styled.div`
@@ -27,4 +45,52 @@ export const CommentContainer = styled.div`
 		height: 20px;
 		padding: 0px;
 	}
+`;
+
+export const AttachmentWrapper = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: ${theme.units.spacing.space12};
+	padding-top: ${theme.units.spacing.space12};
+`;
+
+export const ImageGrid = styled.div<{ count: number }>`
+	display: grid;
+	grid-template-columns: ${(props) =>
+		props.count === 1 ? '1fr' : 'repeat(2, 1fr)'};
+	gap: 20px;
+	max-width: 630px;
+
+	img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+`;
+
+export const ImgContainer = styled.div<{ count: number; index: number }>`
+	position: relative;
+
+	&:hover {
+		.moreText {
+			display: ${(props) =>
+				props.count >= 3 && props.index === 1 ? 'block' : 'none'};
+		}
+	}
+`;
+
+export const ImgWrapper = styled.div<{ count: number; index: number }>`
+	filter: ${(props) =>
+		props.count >= 3 && props.index === 1 ? 'brightness(0.5)' : 'none'};
+`;
+
+export const MoreButton = styled.button`
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+	background: transparent;
+	border: none;
+	font-size: 16px;
+	color: ${theme.color.text.subtle};
 `;

--- a/src/components/Feed/Feed.styled.ts
+++ b/src/components/Feed/Feed.styled.ts
@@ -6,9 +6,25 @@ export const FeedContainer = styled.div`
 	flex-direction: column;
 	gap: ${theme.units.spacing.space20};
 	width: 680px;
-	height: 720px;
+	min-height: 720px;
 	padding: ${theme.units.spacing.space24};
 	border-radius: ${theme.units.radius.radius12};
 	box-shadow: ${theme.elevation.shadow.shadow8};
 	margin-bottom: ${theme.units.spacing.space32};
+`;
+
+export const DetailWrapper = styled.div`
+	min-height: 400px;
+`;
+
+export const CommentContainer = styled.div`
+	display: flex;
+	flex-direction: column;
+	padding: ${theme.units.spacing.space12} ${theme.units.spacing.space8};
+	gap: ${theme.units.spacing.space12};
+
+	button {
+		height: 20px;
+		padding: 0px;
+	}
 `;

--- a/src/components/Feed/Feed.tsx
+++ b/src/components/Feed/Feed.tsx
@@ -13,7 +13,8 @@ interface FeedProps {
 }
 
 const Feed = ({ feedData }: FeedProps) => {
-	const { author, title, createdAt, details, attachments, comments } = feedData;
+	const { author, title, createdAt, details, attachments, comments, images } =
+		feedData;
 
 	return (
 		<S.FeedContainer>
@@ -31,13 +32,31 @@ const Feed = ({ feedData }: FeedProps) => {
 			<Flex direction='column' gap='12'>
 				<Heading size='xs'>{title}</Heading>
 				<Divider size='sm' />
-				{details && <S.DetailWrapper>{details.content}</S.DetailWrapper>}
+				{images.length !== 0 && (
+					<Flex justify='center'>
+						<S.ImageGrid count={images.length}>
+							{images.slice(0, 2).map((image, index) => {
+								return (
+									<S.ImgContainer count={images.length} index={index}>
+										<S.ImgWrapper count={images.length} index={index}>
+											<img alt={image.name} src={image.fileUrl} />
+										</S.ImgWrapper>
+										{images.length >= 3 && index === 1 && (
+											<S.MoreButton>+ 더보기</S.MoreButton>
+										)}
+									</S.ImgContainer>
+								);
+							})}
+						</S.ImageGrid>
+					</Flex>
+				)}
+				{details && <S.DetailWrapper>{`${details.content}`}</S.DetailWrapper>}
 				{attachments.length !== 0 && (
-					<Flex direction='column' gap='12'>
-						{attachments.map((attachment) => {
+					<S.AttachmentWrapper>
+						{attachments.slice(0, 3).map((attachment) => {
 							return <Attachments attachment={attachment} />;
 						})}
-					</Flex>
+					</S.AttachmentWrapper>
 				)}
 				{comments.length !== 0 && (
 					<S.CommentContainer>

--- a/src/components/Feed/Feed.tsx
+++ b/src/components/Feed/Feed.tsx
@@ -1,7 +1,10 @@
+import { Button } from '@components/common/Button/Button';
 import Divider from '@components/common/Divider/Divider';
 import Flex from '@components/common/Flex/Flex';
 import Heading from '@components/common/Heading/Heading';
 import Profile from '@components/common/Profile/Profile';
+import Attachments from '@components/Feed/Attachments/Attachments';
+import Comment from '@components/Feed/Comments/Comment';
 import type { FeedData } from '@type/feed';
 import * as S from './Feed.styled';
 
@@ -10,7 +13,7 @@ interface FeedProps {
 }
 
 const Feed = ({ feedData }: FeedProps) => {
-	const { author, title, createdAt, details } = feedData;
+	const { author, title, createdAt, details, attachments, comments } = feedData;
 
 	return (
 		<S.FeedContainer>
@@ -28,7 +31,36 @@ const Feed = ({ feedData }: FeedProps) => {
 			<Flex direction='column' gap='12'>
 				<Heading size='xs'>{title}</Heading>
 				<Divider size='sm' />
-				{details && <p>{details.content}</p>}
+				{details && <S.DetailWrapper>{details.content}</S.DetailWrapper>}
+				{attachments.length !== 0 && (
+					<Flex direction='column' gap='12'>
+						{attachments.map((attachment) => {
+							return <Attachments attachment={attachment} />;
+						})}
+					</Flex>
+				)}
+				{comments.length !== 0 && (
+					<S.CommentContainer>
+						<Flex direction='column' align='flex-start'>
+							<Button
+								type='button'
+								size='md'
+								variant='text'
+								label={`댓글 ${comments.length}개 모두 보기`}
+								onClick={() => {}}
+							/>
+						</Flex>
+						<Divider size='sm' />
+						{comments.slice(0, 2).map((comment) => {
+							return (
+								<Flex direction='column' gap='8'>
+									<Comment comment={comment} />
+									<Divider size='sm' />
+								</Flex>
+							);
+						})}
+					</S.CommentContainer>
+				)}
 			</Flex>
 		</S.FeedContainer>
 	);

--- a/src/components/common/IconButton/IconButton.styled.ts
+++ b/src/components/common/IconButton/IconButton.styled.ts
@@ -5,10 +5,9 @@ export const IconButtonWrapper = styled.button`
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	padding: 0;
-	box-sizing: border-box;
 	border: none;
 	background-color: transparent;
+	aspect-ratio: 1/1;
 	padding: ${theme.units.spacing.space4};
 	border-radius: ${theme.units.radius.radius6};
 	&:hover {

--- a/src/utils/getUnitFormattedSize.ts
+++ b/src/utils/getUnitFormattedSize.ts
@@ -1,0 +1,12 @@
+export const getUnitFormattedSize = (size: number) => {
+	const units = ['B', 'KB', 'MB'];
+	let formattedSize = size;
+	let unitIndex = 0;
+
+	while (formattedSize >= 1024) {
+		formattedSize /= 1024;
+		unitIndex += 1;
+	}
+
+	return `${formattedSize.toFixed(2)} ${units[unitIndex]}`;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,7 @@
 			"@stores/*": ["src/stores/*"],
 			"@apis/*": ["src/apis/*"],
 			"@hooks/*": ["src/hooks/*"],
+			"@utils/*": ["src/utils/*"],
 			"@assets/*": ["src/assets/*"],
 			"@styles/*": ["src/styles/*"],
 			"@components/*": ["src/components/*"],


### PR DESCRIPTION
## 📌 관련 이슈

- closed : https://github.com/98OO/colla-frontend/issues/86

## ✨ PR 세부 내용
- utils 디렉토리 추가 및 tsconfig, eslintrc 설정
- 파일 단위 변환 유틸 함수 작성
- Download SVG 추가
- 일반 게시글의 파일을 위한 Attachment 컴포넌트 구현
- 피드의 댓글을 위한 Comment 컴포넌트 구현
- 일반 피드 조회 임시 구현

## ✅ 리뷰 요구사항
- 현재 일반 피드 조회는 임시로 구현되어 이후 리팩토링될 예정입니다.
- 파일의 단위를 표시할 때 유틸 함수를 사용해주세요!