### PR TITLE
일반 피드 상세 조회 임시 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,6 +60,7 @@ function App() {
 				</Flex>
 			</Flex>
 			<ToastContainer />
+			<div id='modal-root' />
 		</GlobalErrorBoundary>
 	);
 }

--- a/src/components/Feed/Detail/Normal/NormalDetail.styled.ts
+++ b/src/components/Feed/Detail/Normal/NormalDetail.styled.ts
@@ -1,0 +1,60 @@
+import { styled } from 'styled-components';
+import theme from '@styles/theme';
+
+export const FeedContainer = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: ${theme.units.spacing.space24};
+	width: 680px;
+`;
+
+export const DetailWrapper = styled.div`
+	padding: ${theme.units.spacing.space16} 0;
+	min-height: 50px;
+`;
+
+export const AttachmentWrapper = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: ${theme.units.spacing.space12};
+	padding-top: ${theme.units.spacing.space12};
+`;
+
+export const ImageGrid = styled.div`
+	display: flex;
+	justify-content: center;
+	max-width: 630px;
+
+	img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+`;
+
+export const CommentContainer = styled.div`
+	display: flex;
+	flex-direction: column;
+	padding: ${theme.units.spacing.space12} ${theme.units.spacing.space8};
+	gap: ${theme.units.spacing.space24};
+`;
+
+export const FeedDetailContainer = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: ${theme.units.spacing.space24};
+	width: 680px;
+	height: 100%;
+	padding: ${theme.units.spacing.space24};
+	border-radius: ${theme.units.radius.radius8};
+	overflow-y: scroll;
+
+	&::-webkit-scrollbar {
+		width: 4px;
+	}
+
+	&::-webkit-scrollbar-thumb {
+		border-radius: ${theme.units.radius.radius20};
+		background: ${theme.color.border.secondary};
+	}
+`;

--- a/src/components/Feed/Detail/Normal/NormalDetail.tsx
+++ b/src/components/Feed/Detail/Normal/NormalDetail.tsx
@@ -1,0 +1,76 @@
+import Divider from '@components/common/Divider/Divider';
+import Flex from '@components/common/Flex/Flex';
+import Heading from '@components/common/Heading/Heading';
+import Profile from '@components/common/Profile/Profile';
+import Text from '@components/common/Text/Text';
+import Attachments from '@components/Feed/Attachments/Attachments';
+import Comment from '@components/Feed/Comments/Comment';
+import type { FeedData } from '@type/feed';
+import * as S from './NormalDetail.styled';
+
+interface FeedProps {
+	feedData: FeedData;
+}
+
+const Feed = ({ feedData }: FeedProps) => {
+	const { author, title, createdAt, details, attachments, comments, images } =
+		feedData;
+
+	return (
+		<S.FeedContainer>
+			<Profile
+				profile={author.profileImageUrl}
+				initial={author.username.charAt(0)}
+				avatarSize='lg'
+				title={author.username}
+				titleSize='lg'
+				titleWeight='medium'
+				subTitle={author?.tag?.name || ''}
+				text={createdAt}
+				trailingIcon='Kebab'
+			/>
+			<Flex direction='column' gap='12'>
+				<Heading size='xs'>{title}</Heading>
+				<Divider size='sm' />
+				{images.length !== 0 && (
+					<Flex justify='center'>
+						<S.ImageGrid>
+							{images.map((image) => {
+								return <img alt={image.name} src={image.fileUrl} />;
+							})}
+						</S.ImageGrid>
+					</Flex>
+				)}
+				{details && <S.DetailWrapper>{`${details.content}`}</S.DetailWrapper>}
+				{attachments.length !== 0 && (
+					<S.AttachmentWrapper>
+						{attachments.map((attachment) => {
+							return <Attachments attachment={attachment} />;
+						})}
+					</S.AttachmentWrapper>
+				)}
+				{comments.length !== 0 && (
+					<S.CommentContainer>
+						<Flex direction='column' align='flex-start'>
+							<Text
+								size='md'
+								weight='medium'
+								color='tertiary'>{`댓글 ${comments.length}개`}</Text>
+						</Flex>
+						<Divider size='sm' />
+						{comments.map((comment) => {
+							return (
+								<Flex direction='column' gap='8'>
+									<Comment comment={comment} />
+									<Divider size='sm' />
+								</Flex>
+							);
+						})}
+					</S.CommentContainer>
+				)}
+			</Flex>
+		</S.FeedContainer>
+	);
+};
+
+export default Feed;

--- a/src/components/Feed/Feed.styled.ts
+++ b/src/components/Feed/Feed.styled.ts
@@ -94,3 +94,23 @@ export const MoreButton = styled.button`
 	font-size: 16px;
 	color: ${theme.color.text.subtle};
 `;
+
+export const FeedDetailContainer = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: ${theme.units.spacing.space24};
+	width: 100%;
+	max-height: 80vh;
+	padding: ${theme.units.spacing.space24};
+	border-radius: ${theme.units.radius.radius8};
+	overflow-y: scroll;
+
+	&::-webkit-scrollbar {
+		width: 4px;
+	}
+
+	&::-webkit-scrollbar-thumb {
+		border-radius: ${theme.units.radius.radius20};
+		background: ${theme.color.border.secondary};
+	}
+`;

--- a/src/components/Feed/Feed.tsx
+++ b/src/components/Feed/Feed.tsx
@@ -2,9 +2,12 @@ import { Button } from '@components/common/Button/Button';
 import Divider from '@components/common/Divider/Divider';
 import Flex from '@components/common/Flex/Flex';
 import Heading from '@components/common/Heading/Heading';
+import Modal from '@components/common/Modal/Modal';
 import Profile from '@components/common/Profile/Profile';
 import Attachments from '@components/Feed/Attachments/Attachments';
 import Comment from '@components/Feed/Comments/Comment';
+import NormalDetail from '@components/Feed/Detail/Normal/NormalDetail';
+import { useOverlay } from '@hooks/common/useOverlay';
 import type { FeedData } from '@type/feed';
 import * as S from './Feed.styled';
 
@@ -15,6 +18,7 @@ interface FeedProps {
 const Feed = ({ feedData }: FeedProps) => {
 	const { author, title, createdAt, details, attachments, comments, images } =
 		feedData;
+	const { open, close, isOpen } = useOverlay();
 
 	return (
 		<S.FeedContainer>
@@ -42,7 +46,7 @@ const Feed = ({ feedData }: FeedProps) => {
 											<img alt={image.name} src={image.fileUrl} />
 										</S.ImgWrapper>
 										{images.length >= 3 && index === 1 && (
-											<S.MoreButton>+ 더보기</S.MoreButton>
+											<S.MoreButton onClick={open}>+ 더보기</S.MoreButton>
 										)}
 									</S.ImgContainer>
 								);
@@ -66,7 +70,7 @@ const Feed = ({ feedData }: FeedProps) => {
 								size='md'
 								variant='text'
 								label={`댓글 ${comments.length}개 모두 보기`}
-								onClick={() => {}}
+								onClick={open}
 							/>
 						</Flex>
 						<Divider size='sm' />
@@ -81,6 +85,11 @@ const Feed = ({ feedData }: FeedProps) => {
 					</S.CommentContainer>
 				)}
 			</Flex>
+			<Modal isOpen={isOpen} onClose={close}>
+				<S.FeedDetailContainer>
+					<NormalDetail feedData={feedData} />
+				</S.FeedDetailContainer>
+			</Modal>
 		</S.FeedContainer>
 	);
 };

--- a/src/components/common/Modal/Modal.styled.ts
+++ b/src/components/common/Modal/Modal.styled.ts
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+import theme from '@styles/theme';
+
+export const Backdrop = styled.div`
+	position: fixed;
+	top: 0;
+	left: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	height: 100%;
+	background: rgba(0, 0, 0, 0.4);
+	z-index: ${theme.elevation.zIndex.MODAL};
+`;
+
+export const ModalWrapper = styled.div`
+	background: ${theme.color.bg.primary};
+	border-radius: ${theme.units.radius.radius8};
+	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+`;

--- a/src/components/common/Modal/Modal.tsx
+++ b/src/components/common/Modal/Modal.tsx
@@ -1,0 +1,35 @@
+import { useEffect, ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import * as S from './Modal.styled';
+
+interface ModalProps {
+	isOpen: boolean;
+	onClose: () => void;
+	children: ReactNode;
+}
+
+const Modal = ({ isOpen, onClose, children }: ModalProps) => {
+	useEffect(() => {
+		const handleEscape = (event: KeyboardEvent) => {
+			if (event.key === 'Escape') onClose();
+		};
+		document.addEventListener('keydown', handleEscape);
+
+		return () => {
+			document.removeEventListener('keydown', handleEscape);
+		};
+	}, [onClose]);
+
+	const modalRoot = document.getElementById('modal-root');
+
+	if (!isOpen || !modalRoot) return null;
+
+	return createPortal(
+		<S.Backdrop onClick={onClose}>
+			<S.ModalWrapper>{children}</S.ModalWrapper>
+		</S.Backdrop>,
+		modalRoot
+	);
+};
+
+export default Modal;

--- a/src/hooks/common/useOverlay.ts
+++ b/src/hooks/common/useOverlay.ts
@@ -1,0 +1,19 @@
+import { useState, useCallback } from 'react';
+
+export const useOverlay = () => {
+	const [isOpen, setIsOpen] = useState(false);
+
+	const open = useCallback(() => {
+		setIsOpen(true);
+	}, [setIsOpen]);
+
+	const close = useCallback(() => {
+		setIsOpen(false);
+	}, [setIsOpen]);
+
+	const toggle = useCallback(() => {
+		setIsOpen((prev) => !prev);
+	}, []);
+
+	return { isOpen, open, close, toggle };
+};


### PR DESCRIPTION
## 📌 관련 이슈

- closed : https://github.com/98OO/colla-frontend/issues/86

## ✨ PR 세부 내용
- 오버레이(예: 모달 창)의 열림/닫힘 상태 관리를 위한 useOverlay 커스텀 훅 추가
- createPortal을 사용한 모달 컴포넌트 구현
- 일반 피드 상세 조회를 위한 NormalDetail 컴포넌트 작성 및 useOverlay 훅과 모달 적용

## ✅ 리뷰 요구사항
현재 임시적으로 피드 상세 조회를 위해 모달을 사용해 피드에서 일부 개수만 보였던 일반 피드의 전체 내용을 사용자가 확인할 수 있도록 구현했습니다. 이후 UI 수정 예정입니다.
