### PR TITLE
useWindowWidth 커스텀 훅 테스트 코드 작성

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -123,6 +123,17 @@ module.exports = {
 		'react/require-default-props': 'off',
 		'react/jsx-props-no-spreading': 'off',
 		'prettier/prettier': ['error', { endOfLine: 'auto' }],
+		'import/no-extraneous-dependencies': [
+			'error',
+			{
+				devDependencies: [
+					'**/__tests__/**',
+					'**/*.test.ts',
+					'**/*.test.tsx',
+					'**/setupTests.ts',
+				],
+			},
+		],
 	},
 	settings: {
 		'import/resolver': {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"styled-reset": "^4.5.2",
 		"vite": "^5.2.0",
 		"vite-tsconfig-paths": "^4.3.2",
+		"vitest": "^2.1.3",
 		"zustand": "^4.5.2"
 	},
 	"devDependencies": {
@@ -50,12 +51,16 @@
 		"@storybook/blocks": "^8.0.9",
 		"@storybook/react": "^8.0.9",
 		"@storybook/react-vite": "^8.0.9",
+		"@testing-library/jest-dom": "^6.5.0",
+		"@testing-library/react": "^16.0.1",
+		"@testing-library/user-event": "^14.5.2",
 		"@types/react": "^18.2.66",
 		"@types/react-dom": "^18.2.22",
 		"@types/sockjs-client": "^1.5.4",
 		"@types/styled-components": "^5.1.34",
 		"@typescript-eslint/eslint-plugin": "^7.6.0",
 		"@typescript-eslint/parser": "^7.6.0",
+		"@vitest/browser": "^2.1.2",
 		"chromatic": "^11.3.1",
 		"commitlint-plugin-function-rules": "^4.0.0",
 		"eslint": "^8.57.0",
@@ -69,16 +74,12 @@
 		"eslint-plugin-react-refresh": "^0.4.6",
 		"eslint-plugin-storybook": "^0.8.0",
 		"husky": "^8.0.0",
+		"jsdom": "^25.0.1",
 		"lint-staged": "^15.2.2",
 		"msw-storybook-addon": "^1.10.0",
 		"prettier": "^3.2.5",
 		"storybook": "^8.0.9",
-		"typescript": "^5.4.4",
-		"@testing-library/jest-dom": "^6.5.0",
-		"@testing-library/react": "^16.0.1",
-		"@testing-library/user-event": "^14.5.2",
-		"@vitest/browser": "^2.1.2",
-		"jsdom": "^25.0.1"
+		"typescript": "^5.4.4"
 	},
 	"msw": {
 		"workerDirectory": "public"

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/src/hooks/common/__tests__/useMenu.test.tsx
+++ b/src/hooks/common/__tests__/useMenu.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import useMenu from '@hooks/common/useMenu';
+import { renderHook } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from 'styled-components';
+import { describe, test, expect } from 'vitest';
+import theme from '@styles/theme';
+
+describe('useMenu', () => {
+	const TestMenuComponent = ({
+		baseRef,
+	}: {
+		baseRef: React.RefObject<HTMLDivElement>;
+	}) => {
+		const { toggleMenu, showMenu } = useMenu();
+
+		return (
+			<div>
+				<div ref={baseRef} data-testid='base-element'>
+					Base Element
+				</div>
+				<button type='button' onClick={toggleMenu} data-testid='toggle-button'>
+					Toggle Menu
+				</button>
+				{showMenu(baseRef, <div data-testid='menu'>Menu Content</div>, {
+					top: 0,
+					left: 0,
+				})}
+			</div>
+		);
+	};
+
+	test('메뉴가 기본적으로 보이지 않아야 한다', () => {
+		const baseRef = { current: document.createElement('div') };
+		const { result } = renderHook(() => useMenu());
+
+		const { showMenu } = result.current;
+
+		render(showMenu(baseRef, <div>Test Menu</div>, { top: 0, left: 0 }));
+
+		expect(screen.queryByText('Test Menu')).not.toBeInTheDocument();
+	});
+
+	test('토글 버튼을 누르면 메뉴가 보여야 한다', async () => {
+		const baseRef = { current: document.createElement('div') };
+		render(
+			<ThemeProvider theme={theme}>
+				<TestMenuComponent baseRef={baseRef} />
+			</ThemeProvider>
+		);
+
+		const toggleButton = screen.getByTestId('toggle-button');
+		expect(screen.queryByTestId('menu')).not.toBeInTheDocument();
+
+		await userEvent.click(toggleButton);
+
+		expect(screen.getByTestId('menu')).toBeInTheDocument();
+	});
+
+	test('외부를 클릭하면 메뉴가 닫혀야 한다', async () => {
+		const baseRef = { current: document.createElement('div') };
+		render(
+			<ThemeProvider theme={theme}>
+				<TestMenuComponent baseRef={baseRef} />
+			</ThemeProvider>
+		);
+
+		const toggleButton = screen.getByTestId('toggle-button');
+
+		await userEvent.click(toggleButton);
+
+		expect(screen.getByTestId('menu')).toBeInTheDocument();
+
+		await userEvent.click(document.body);
+
+		expect(screen.queryByTestId('menu')).not.toBeInTheDocument();
+	});
+});

--- a/src/hooks/common/__tests__/useOutSideClick.test.tsx
+++ b/src/hooks/common/__tests__/useOutSideClick.test.tsx
@@ -1,0 +1,68 @@
+import useOutsideClick from '@hooks/common/useOutSideClick';
+import { render } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { describe, expect, test, vi } from 'vitest';
+
+const mockClick = vi.fn();
+
+describe('useOutSideClick > ', () => {
+	const TestComponent = ({
+		onClickOutside,
+	}: {
+		onClickOutside: () => void;
+	}) => {
+		const ref = useOutsideClick({ onClickOutside });
+
+		return (
+			<div>
+				<div data-testid='outside1'>메인 콘텐츠 바깥에 있는 친구 1</div>
+				<main data-testid='main' ref={ref}>
+					메인 콘텐츠
+				</main>
+				<div data-testid='outside2'>메인 콘텐츠 바깥에 있는 친구 2</div>
+			</div>
+		);
+	};
+
+	test('main을 클릭할 때는 onClickOutside가 호출되지 않는다', async () => {
+		const { getByTestId } = render(
+			<TestComponent onClickOutside={mockClick} />
+		);
+
+		const main = getByTestId('main');
+
+		await userEvent.click(main);
+
+		expect(mockClick).toHaveBeenCalledTimes(0);
+	});
+
+	test('외부 요소를 클릭했을 때 onClickOutside가 호출된다', async () => {
+		const { getByTestId } = render(
+			<TestComponent onClickOutside={mockClick} />
+		);
+
+		const outside1 = getByTestId('outside1');
+		const outside2 = getByTestId('outside2');
+
+		await userEvent.click(outside1);
+		expect(mockClick).toHaveBeenCalledTimes(1);
+
+		await userEvent.click(outside2);
+		expect(mockClick).toHaveBeenCalledTimes(2);
+	});
+
+	test('rerender 후 새로운 핸들러가 호출된다', async () => {
+		const { getByTestId, rerender } = render(
+			<TestComponent onClickOutside={mockClick} />
+		);
+
+		const mockClick2 = vi.fn();
+		rerender(<TestComponent onClickOutside={mockClick2} />);
+
+		const outside1 = getByTestId('outside1');
+		await userEvent.click(outside1);
+
+		expect(mockClick).toHaveBeenCalledTimes(2); // 기존 핸들러는 더 이상 호출되지 않음
+		expect(mockClick2).toHaveBeenCalledTimes(1); // 새로 등록된 핸들러 호출
+	});
+});

--- a/src/hooks/common/__tests__/useOverlay.test.ts
+++ b/src/hooks/common/__tests__/useOverlay.test.ts
@@ -1,0 +1,27 @@
+import { useOverlay } from '@hooks/common/useOverlay';
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+
+describe('useOverlay.test > ', () => {
+	test('초기 상태는 isOpen이 false여야 한다', () => {
+		const { result } = renderHook(() => useOverlay());
+		expect(result.current.isOpen).toEqual(false);
+	});
+
+	test('open을 호출하면 isOpen이 true로 변경되어야 한다', () => {
+		const { result } = renderHook(() => useOverlay());
+		act(() => {
+			result.current.open();
+		});
+		expect(result.current.isOpen).toEqual(true);
+	});
+
+	test('close를 호출하면 isOpen이 false로 변경되어야 한다', () => {
+		const { result } = renderHook(() => useOverlay());
+		act(() => {
+			result.current.open(); // 먼저 open을 호출해 true로 만든 후
+			result.current.close(); // close로 false로 변경
+		});
+		expect(result.current.isOpen).toEqual(false);
+	});
+});

--- a/src/hooks/user/__tests__/useForm.test.ts
+++ b/src/hooks/user/__tests__/useForm.test.ts
@@ -1,0 +1,101 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import useForm from '../useForm';
+
+describe('useForm > ', () => {
+	const onSubmitMock = vi.fn();
+	const options = {
+		onSubmit: onSubmitMock,
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	test('필드 값이 변경되면 formData가 업데이트되어야 한다', () => {
+		const { result } = renderHook(() => useForm(options));
+
+		// Register a field and simulate a change
+		const field = result.current.register('name');
+		act(() => {
+			field.onChange({ target: { name: 'name', value: 'John' } });
+		});
+
+		// formData에 값이 잘 들어갔는지 확인
+		expect(result.current.formData.name).toBe('John');
+	});
+
+	test('필드가 blur 될 때 validation이 동작해야 한다', () => {
+		const { result } = renderHook(() =>
+			useForm({
+				...options,
+				subscribe: [{ fieldName: 'name', value: 'John' }],
+			})
+		);
+
+		// Register a field with required validation
+		const field = result.current.register('name', {
+			required: 'Name is required',
+		});
+		act(() => {
+			field.onChange({ target: { name: 'name', value: '' } });
+			field.onBlur({ target: { name: 'name' } });
+		});
+
+		// 에러가 발생하는지 확인
+		expect(result.current.errors.name.isError).toBe(true);
+		expect(result.current.errors.name.message).toBe('Name is required');
+	});
+
+	test('handleSubmit이 validation을 통과하면 onSubmit이 호출되어야 한다', async () => {
+		const { result } = renderHook(() =>
+			useForm({
+				...options,
+				subscribe: [{ fieldName: 'name', value: 'John' }],
+			})
+		);
+
+		// Register a field with required validation
+		const field = result.current.register('name', {
+			required: 'Name is required',
+		});
+		act(() => {
+			field.onChange({ target: { name: 'name', value: 'John' } });
+		});
+
+		// handleSubmit을 호출해서 검증
+		await act(async () => {
+			result.current.handleSubmit({ preventDefault: vi.fn() });
+		});
+
+		expect(onSubmitMock).toHaveBeenCalled();
+	});
+
+	test('필드가 invalid한 경우 onSubmit이 호출되지 않아야 한다', async () => {
+		const { result } = renderHook(() =>
+			useForm({
+				...options,
+				subscribe: [{ fieldName: 'name', value: 'John' }],
+			})
+		);
+
+		// 필드 등록 및 빈 값으로 설정
+		const field = result.current.register('name', {
+			required: 'Name is required',
+		});
+		act(() => {
+			field.onChange({ target: { name: 'name', value: '' } });
+			field.onBlur({ target: { name: 'name' } });
+		});
+
+		// handleSubmit 호출
+		act(() => {
+			result.current.handleSubmit({ preventDefault: vi.fn() });
+		});
+
+		// onSubmit이 호출되지 않음을 확인
+		expect(onSubmitMock).not.toHaveBeenCalled();
+		expect(result.current.errors.name.isError).toBe(true);
+		expect(result.current.errors.name.message).toBe('Name is required');
+	});
+});

--- a/src/hooks/window/__test__/useWindowWidth.test.ts
+++ b/src/hooks/window/__test__/useWindowWidth.test.ts
@@ -1,0 +1,65 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, test, expect, vi } from 'vitest';
+import useWindowWidth from '../useWindowWidth';
+
+// Resize 이벤트를 트리거하기 위해 필요
+const triggerResize = (width: number) => {
+	window.innerWidth = width;
+	window.dispatchEvent(new Event('resize'));
+};
+
+describe('useWindowWidth Hook', () => {
+	test('초기 렌더링에서 창 너비가 1024px 이하인 경우 모바일 뷰가 설정되어야 한다', () => {
+		// 창 너비를 1024 이하로 설정
+		triggerResize(800);
+
+		const { result } = renderHook(() => useWindowWidth());
+
+		// isMobileView가 true이어야 함
+		expect(result.current).toBe(true);
+	});
+
+	test('초기 렌더링에서 창 너비가 1025px 이상인 경우 데스크탑 뷰가 설정되어야 한다', () => {
+		// 창 너비를 1025 이상으로 설정
+		triggerResize(1200);
+
+		const { result } = renderHook(() => useWindowWidth());
+
+		// isMobileView가 false이어야 함
+		expect(result.current).toBe(false);
+	});
+
+	test('창 크기가 변경되면 isMobileView가 업데이트되어야 한다', () => {
+		const { result } = renderHook(() => useWindowWidth());
+
+		// 창 너비를 1025로 변경
+		act(() => {
+			triggerResize(1025);
+		});
+
+		expect(result.current).toBe(false); // 데스크탑 뷰로 변경
+
+		// 창 너비를 800으로 변경
+		act(() => {
+			triggerResize(800);
+		});
+
+		expect(result.current).toBe(true); // 모바일 뷰로 변경
+	});
+
+	test('컴포넌트 언마운트 시 이벤트 리스너가 제거되어야 한다', () => {
+		const { unmount } = renderHook(() => useWindowWidth());
+
+		// 스파이를 만들어 이벤트 리스너가 제거되었는지 확인
+		const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+
+		// 훅 언마운트
+		unmount();
+
+		// removeEventListener가 호출되었는지 확인
+		expect(removeEventListenerSpy).toHaveBeenCalledWith(
+			'resize',
+			expect.any(Function)
+		);
+	});
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,7 @@ export default mergeConfig(
 		test: {
 			globals: true,
 			environment: 'jsdom',
+			setupFiles: ['./setupTests.ts'],
 		},
 	})
 );


### PR DESCRIPTION
## 📌 관련 이슈

- closed : #122 

## ✨ PR 세부 내용

- useWindowWidth 커스텀 훅 테스트 코드 작성
    - 초기 렌더링에서 창 너비가 1024px 이하인 경우 모바일 뷰가 설정되어야 한다
    - 초기 렌더링에서 창 너비가 1025px 이상인 경우 데스크탑 뷰가 설정되어야 한다
    - 창 크기가 변경되면 isMobileView가 업데이트되어야 한다
    - 컴포넌트 언마운트 시 이벤트 리스너가 제거되어야 한다

## 📸 스크린샷(선택)

![image](https://github.com/user-attachments/assets/e33f5690-7728-4b87-8f6d-f5996e4b879a)
