### PR TITLE
LNB 컴포넌트 구현

### DIFF
--- a/src/components/Post/LNB/LNB.styled.ts
+++ b/src/components/Post/LNB/LNB.styled.ts
@@ -1,0 +1,28 @@
+import styled from 'styled-components';
+import theme from '@styles/theme';
+
+export const LNBContainer = styled.nav`
+	display: flex;
+	width: 680px;
+	height: ${theme.units.spacing.space48};
+	cursor: pointer;
+`;
+
+export const LNBItemContainer = styled.div<{ active?: boolean }>`
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	width: 170px;
+	border-bottom: 2px solid
+		${({ active }) =>
+			active ? theme.color.border.iPrimary : theme.color.border.tertiary};
+	font-weight: ${({ active }) =>
+		active
+			? theme.typography.fontWeight.semiBold
+			: theme.typography.fontWeight.regular};
+
+	&:hover {
+		background-color: ${theme.color.bg.iSecondaryHover};
+		transition: background-color 0.2s ease-in-out;
+	}
+`;

--- a/src/components/Post/LNB/LNB.tsx
+++ b/src/components/Post/LNB/LNB.tsx
@@ -1,0 +1,52 @@
+import { useNavigate } from 'react-router-dom';
+import { PATH } from '@constants/path';
+import type { FeedMenuType } from '@type/feed';
+import * as S from './LNB.styled';
+
+interface LNBItemProps {
+	label: string;
+	active?: boolean;
+	onClick: () => void;
+}
+
+interface LNBProps {
+	selected: FeedMenuType;
+}
+
+type LNBItem = { label: string; type: FeedMenuType }[];
+
+const LNB_ITEMS: LNBItem = [
+	{ label: '일반 게시글', type: 'normal' },
+	{ label: '일정 조율', type: 'scheduling' },
+	{ label: '투표', type: 'vote' },
+	{ label: '자료 수집', type: 'collect' },
+];
+
+const LNBItem = ({ label, active, onClick }: LNBItemProps) => (
+	<S.LNBItemContainer active={active} onClick={onClick}>
+		{label}
+	</S.LNBItemContainer>
+);
+
+const LNB = ({ selected }: LNBProps) => {
+	const navigate = useNavigate();
+
+	const handleItemClick = (type: FeedMenuType) => {
+		navigate(`${PATH.POST}?type=${type}`);
+	};
+
+	return (
+		<S.LNBContainer>
+			{LNB_ITEMS.map(({ label, type }) => (
+				<LNBItem
+					key={type}
+					label={label}
+					onClick={() => handleItemClick(type)}
+					active={selected === type}
+				/>
+			))}
+		</S.LNBContainer>
+	);
+};
+
+export default LNB;

--- a/src/pages/PostPage/PostPage.styled.ts
+++ b/src/pages/PostPage/PostPage.styled.ts
@@ -1,0 +1,12 @@
+import { styled } from 'styled-components';
+import theme from '@styles/theme';
+
+export const Container = styled.div`
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: ${theme.units.spacing.space32};
+	width: 100%;
+	height: 100%;
+	padding-top: ${theme.units.spacing.space24};
+`;

--- a/src/pages/PostPage/PostPage.tsx
+++ b/src/pages/PostPage/PostPage.tsx
@@ -1,10 +1,17 @@
 import { useLocation } from 'react-router-dom';
+import LNB from '@components/Post/LNB/LNB';
+import type { FeedMenuType } from '@type/feed';
+import * as S from './PostPage.styled';
 
 const PostPage = () => {
-	const location = useLocation();
-	const queryParams = new URLSearchParams(location.search);
-	const feedType = queryParams.get('type');
+	const { search } = useLocation();
+	const feedType = new URLSearchParams(search).get('type') as FeedMenuType;
 
-	return <div>{feedType}</div>;
+	return (
+		<S.Container>
+			<LNB selected={feedType} />
+		</S.Container>
+	);
 };
+
 export default PostPage;


### PR DESCRIPTION
## 📌 관련 이슈
- closed : https://github.com/98OO/colla-frontend/issues/127

## ✨ PR 세부 내용
- 피드 타입별 작성 페이지 이동을 위한 LNB 컴포넌트 구현
- 작성 페이지 path는 타입 별로 `/feed/post/new?type=타입` 입니다

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/c57caf3a-1073-4a73-8397-c20c0c029ff0)
