### PR TITLE
팀스페이스의 읽지 않은 전체 채팅 개수 제공

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,8 @@ function App() {
 			client.connect({}, () => {
 				setStompClient(client);
 			});
+
+			client.debug = () => {};
 		}
 	};
 

--- a/src/components/Chat/ChatRoom/ChatRoom.styled.ts
+++ b/src/components/Chat/ChatRoom/ChatRoom.styled.ts
@@ -26,7 +26,7 @@ export const MessageContainer = styled.div`
 	width: 315px;
 	flex-grow: 1;
 
-	p {
+	> * {
 		overflow: hidden;
 		white-space: nowrap;
 		text-overflow: ellipsis;

--- a/src/components/Chat/ChatRoom/ChatRoomCreationModal/ChatRoomCreationModal.tsx
+++ b/src/components/Chat/ChatRoom/ChatRoomCreationModal/ChatRoomCreationModal.tsx
@@ -38,6 +38,8 @@ const ChatRoomCreationModal = ({
 			setNameError('팀스페이스 이름은 공백일 수 없습니다.');
 		else if (teamspaceName.length < 2)
 			setNameError('팀스페이스 이름은 2글자 이상입니다.');
+		else if (teamspaceName.length > 15)
+			setNameError('팀스페이스 이름은 15글자 이하입니다.');
 		else {
 			setNameError('');
 			return true;

--- a/src/components/Chat/Chatting/Chatting.tsx
+++ b/src/components/Chat/Chatting/Chatting.tsx
@@ -311,13 +311,18 @@ const Chatting = (props: ChattingProps) => {
 	};
 
 	const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
-		if (event.key === 'Enter') {
-			if (!event.shiftKey) {
-				event.preventDefault();
-				if (chatMessage.length !== 0) {
-					handleText();
-				}
-			}
+		if (event.nativeEvent.isComposing) return;
+
+		if (event.key === 'Enter' && event.shiftKey) {
+			event.preventDefault();
+			setChatMessage((prev) => `${prev}\n`);
+		} else if (
+			event.key === 'Enter' &&
+			!event.shiftKey &&
+			chatMessage.length > 0
+		) {
+			event.preventDefault();
+			handleText();
 		}
 	};
 

--- a/src/components/Chat/MyMessageBox/MyMessageBox.styled.ts
+++ b/src/components/Chat/MyMessageBox/MyMessageBox.styled.ts
@@ -23,6 +23,7 @@ export const MyMessageBoxWrapper = styled.div<{ state: boolean; type: string }>`
 	max-width: 250px;
 	line-height: 18px;
 	word-break: break-all;
+	white-space: pre-line;
 `;
 
 export const ImageWrapper = styled.div`

--- a/src/components/Chat/OtherMessageBox/OtherMessageBox.styled.ts
+++ b/src/components/Chat/OtherMessageBox/OtherMessageBox.styled.ts
@@ -27,6 +27,7 @@ export const OtherMessageBoxWrapper = styled.div<{
 	max-width: 250px;
 	line-height: 18px;
 	word-break: break-all;
+	white-space: pre-line;
 `;
 
 export const ImageWrapper = styled.div`

--- a/src/components/common/GNB/GNB.tsx
+++ b/src/components/common/GNB/GNB.tsx
@@ -83,8 +83,6 @@ const GNB = () => {
 					newChatMessageSubscribe;
 		}
 
-		setChatChannelList([]);
-
 		return () => {
 			if (chatChannelsSubscribeRef.current.chatChannelListSubscribe)
 				chatChannelsSubscribeRef.current.chatChannelListSubscribe.unsubscribe();

--- a/src/components/common/GNB/GNBMenu/GNBTeamSpace/GNBTeamSpace.tsx
+++ b/src/components/common/GNB/GNBMenu/GNBTeamSpace/GNBTeamSpace.tsx
@@ -6,18 +6,10 @@ import Profile from '@components/common/Profile/Profile';
 import Text from '@components/common/Text/Text';
 import useRecordTeamSpace from '@hooks/queries/teamspace/useRecordTeamSpace';
 import useUserStatusQuery from '@hooks/queries/useUserStatusQuery';
-import { StompSubscription } from '@stomp/stompjs';
 import { PATH } from '@constants/path';
 import * as S from './GNBTeamSpace.syled';
 
-const GNBTeamSpace = ({
-	chatChannelsStatus,
-}: {
-	chatChannelsStatus: {
-		chatChannelListStatus?: StompSubscription;
-		chatMessageStatus?: StompSubscription;
-	};
-}) => {
+const GNBTeamSpace = () => {
 	const { userStatus } = useUserStatusQuery();
 	const { mutateRecordTeamSpace } = useRecordTeamSpace();
 	const navigate = useNavigate();
@@ -27,14 +19,9 @@ const GNBTeamSpace = ({
 	const otherProfiles = userStatus?.participatedTeamspaces.filter(
 		(teamSpace) => teamSpace.name !== lastSeenTeam?.name
 	);
+
 	const handleTeamChangeClick = (teamSpaceId: number) => {
 		mutateRecordTeamSpace(teamSpaceId);
-		if (chatChannelsStatus.chatChannelListStatus)
-			chatChannelsStatus.chatChannelListStatus.unsubscribe();
-
-		if (chatChannelsStatus.chatMessageStatus)
-			chatChannelsStatus.chatMessageStatus.unsubscribe();
-
 		navigate(PATH.FEED);
 	};
 

--- a/src/components/common/GNB/GNBMenu/GNBTeamSpace/GNBTeamSpace.tsx
+++ b/src/components/common/GNB/GNBMenu/GNBTeamSpace/GNBTeamSpace.tsx
@@ -6,6 +6,7 @@ import Profile from '@components/common/Profile/Profile';
 import Text from '@components/common/Text/Text';
 import useRecordTeamSpace from '@hooks/queries/teamspace/useRecordTeamSpace';
 import useUserStatusQuery from '@hooks/queries/useUserStatusQuery';
+import useSocketStore from '@stores/socketStore';
 import { PATH } from '@constants/path';
 import * as S from './GNBTeamSpace.syled';
 
@@ -13,6 +14,7 @@ const GNBTeamSpace = () => {
 	const { userStatus } = useUserStatusQuery();
 	const { mutateRecordTeamSpace } = useRecordTeamSpace();
 	const navigate = useNavigate();
+
 	const lastSeenTeam = userStatus?.participatedTeamspaces.find(
 		(team) => team.teamspaceId === userStatus?.profile.lastSeenTeamspaceId
 	);
@@ -20,8 +22,12 @@ const GNBTeamSpace = () => {
 		(teamSpace) => teamSpace.name !== lastSeenTeam?.name
 	);
 
+	const { increaseChatMessageCount, setChatChannelList } = useSocketStore();
+
 	const handleTeamChangeClick = (teamSpaceId: number) => {
 		mutateRecordTeamSpace(teamSpaceId);
+		increaseChatMessageCount(null);
+		setChatChannelList([]);
 		navigate(PATH.FEED);
 	};
 

--- a/src/components/common/SideNavigationBar/SNBFull/SNBFull.tsx
+++ b/src/components/common/SideNavigationBar/SNBFull/SNBFull.tsx
@@ -23,6 +23,9 @@ const SNBFull = () => {
 	const teamRole = teamspaces?.find(
 		(teamspace) => teamspace.teamspaceId === lastSeenTeamspaceId
 	)?.teamspaceRole;
+	const unreadMessageCount = teamspaces?.find(
+		(teamspace) => teamspace.teamspaceId === lastSeenTeamspaceId
+	)?.unreadMessageCount;
 
 	const { chatMessageCount } = useSocketStore();
 	const baseRef = useRef<HTMLDivElement>(null);
@@ -62,7 +65,9 @@ const SNBFull = () => {
 						leadingIcon='Message'
 						title='채팅'
 						selected={location.pathname === PATH.CHAT}
-						number={chatMessageCount}
+						number={
+							chatMessageCount === null ? unreadMessageCount : chatMessageCount
+						}
 						onClick={() => navigate(PATH.CHAT)}
 					/>
 					<MenuItem

--- a/src/components/common/SideNavigationBar/SNBIcon/SNBIcon.tsx
+++ b/src/components/common/SideNavigationBar/SNBIcon/SNBIcon.tsx
@@ -6,6 +6,7 @@ import Flex from '@components/common/Flex/Flex';
 import FeedMenu from '@components/common/SideNavigationBar/FeedMenu/FeedMenu';
 import MenuItem from '@components/common/SideNavigationBar/MenuItem/MenuItem';
 import useMenu from '@hooks/common/useMenu';
+import useUserStatusQuery from '@hooks/queries/useUserStatusQuery';
 import useSocketStore from '@stores/socketStore';
 import { PATH } from '@constants/path';
 import { SNB_ICON_WIDTH } from '@styles/layout';
@@ -14,6 +15,16 @@ import * as S from './SNBIcon.styled';
 const SNBIcon = () => {
 	const navigate = useNavigate();
 	const location = useLocation();
+	const { userStatus } = useUserStatusQuery();
+	const lastSeenTeamspaceId = userStatus?.profile.lastSeenTeamspaceId;
+	const teamspaces = userStatus?.participatedTeamspaces;
+	const teamRole = teamspaces?.find(
+		(teamspace) => teamspace.teamspaceId === lastSeenTeamspaceId
+	)?.teamspaceRole;
+	const unreadMessageCount = teamspaces?.find(
+		(teamspace) => teamspace.teamspaceId === lastSeenTeamspaceId
+	)?.unreadMessageCount;
+
 	const { chatMessageCount } = useSocketStore();
 	const baseRef = useRef<HTMLDivElement>(null);
 	const { toggleMenu: handleFeedMenu, showMenu: showFeedMenu } = useMenu();
@@ -50,7 +61,9 @@ const SNBIcon = () => {
 					<MenuItem
 						leadingIcon='Message'
 						selected={location.pathname === PATH.CHAT}
-						number={chatMessageCount}
+						number={
+							chatMessageCount === null ? unreadMessageCount : chatMessageCount
+						}
 						type='iconOnly'
 						onClick={() => navigate(PATH.CHAT)}
 					/>
@@ -69,12 +82,14 @@ const SNBIcon = () => {
 				</Flex>
 				<Flex direction='column' gap='8' align='center'>
 					<Divider size='sm' />
-					<MenuItem
-						leadingIcon='Settings'
-						selected={location.pathname === PATH.SETTING}
-						type='iconOnly'
-						onClick={() => navigate(PATH.SETTING)}
-					/>
+					{teamRole === 'LEADER' && (
+						<MenuItem
+							leadingIcon='Settings'
+							selected={location.pathname === PATH.SETTING}
+							type='iconOnly'
+							onClick={() => navigate(PATH.SETTING)}
+						/>
+					)}
 					<MenuItem
 						leadingIcon='PlusBox'
 						selected={false}

--- a/src/hooks/queries/chat/useCreateChatChannelMutation.tsx
+++ b/src/hooks/queries/chat/useCreateChatChannelMutation.tsx
@@ -1,14 +1,17 @@
 import postCreateChatChannel from '@apis/chat/postCreateChatChannel';
 import { useMutation } from '@hooks/queries/common/useMutation';
 import { useQueryClient } from '@tanstack/react-query';
+import useSocketStore from '@stores/socketStore';
 import useToastStore from '@stores/toastStore';
 
 const useCreateChatChannelMutation = () => {
 	const { makeToast } = useToastStore();
 	const queryClient = useQueryClient();
+	const { setChatChannelList } = useSocketStore();
 
 	const handleCreateChatChannelSucess = () => {
 		makeToast('채팅방 생성이 완료됬습니다.', 'Success');
+		setChatChannelList([]);
 		queryClient.invalidateQueries({ queryKey: ['chatChannel'] });
 	};
 

--- a/src/hooks/queries/teamspace/useRecordTeamSpace.ts
+++ b/src/hooks/queries/teamspace/useRecordTeamSpace.ts
@@ -8,6 +8,7 @@ const useRecordTeamSpace = () => {
 	const handleSettingSucess = () => {
 		queryClient.invalidateQueries({ queryKey: ['userStatus'] });
 		queryClient.invalidateQueries({ queryKey: ['teamSetting'] });
+		queryClient.refetchQueries({ queryKey: ['chatChannel'] });
 	};
 
 	const { mutate } = useMutation({

--- a/src/hooks/queries/useLoginMutation.tsx
+++ b/src/hooks/queries/useLoginMutation.tsx
@@ -27,6 +27,8 @@ const useLoginMutation = () => {
 				setStompClient(client);
 			});
 
+			client.debug = () => {};
+
 			if (inviteUrl) {
 				window.sessionStorage.removeItem(INVITE_URL);
 				navigate(`${PATH.INVITE}${inviteUrl}`);

--- a/src/hooks/queries/useOauthLoginMutation.tsx
+++ b/src/hooks/queries/useOauthLoginMutation.tsx
@@ -25,6 +25,9 @@ const useOauthLoginMutation = () => {
 			client.connect({}, () => {
 				setStompClient(client);
 			});
+
+			client.debug = () => {};
+
 			if (inviteUrl) {
 				window.sessionStorage.removeItem(INVITE_URL);
 				navigate(`${PATH.INVITE}${inviteUrl}`);

--- a/src/stores/socketStore.ts
+++ b/src/stores/socketStore.ts
@@ -12,8 +12,8 @@ interface ChatChannel {
 type socketStore = {
 	stompClient: CompatClient | null;
 	setStompClient: (client: CompatClient | null) => void;
-	chatMessageCount: number;
-	increaseChatMessageCount: (number: number) => void;
+	chatMessageCount: number | null;
+	increaseChatMessageCount: (number: number | null) => void;
 	chatChannelList: ChatChannel[];
 	setChatChannelList: (channels: ChatChannel[]) => void;
 };
@@ -21,7 +21,7 @@ type socketStore = {
 const useSocketStore = create<socketStore>((set) => ({
 	stompClient: null,
 	setStompClient: (client) => set({ stompClient: client }),
-	chatMessageCount: 0,
+	chatMessageCount: null,
 	increaseChatMessageCount: (count) => set({ chatMessageCount: count }),
 	chatChannelList: [],
 	setChatChannelList: (channels) => set({ chatChannelList: channels }),

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -18,6 +18,7 @@ interface ParticipatedTeamspace {
 	profileImageUrl: string;
 	teamspaceRole: string;
 	numOfParticipants: number;
+	unreadMessageCount: number;
 }
 
 export interface UserInformation {


### PR DESCRIPTION
## 📌 관련 이슈

- closed: https://github.com/98OO/colla-frontend/issues/132

## ✨ PR 세부 내용

- 각 팀스페이스마다 읽지 않은 전체 채팅 개수 제공
- SockJS 디버그 메시지 비활성화
- useRef를 사용해 팀스페이스 채팅방 목록 구독 상태 관리
- Enter 키 입력 시 메시지 중복 전송 문제 해결을 위한 event.nativeEvent.isComposing 조건 추가
- 채팅방 이름 및 마지막 메시지 말줄임 처리 수정

## ✅ 리뷰 요구사항(선택)

- 채팅 사용 시 발생하는 문제에 대해서 말씀해 주시면 추후 반영하여 해결하겠습니다.
