### PR TITLE
GNB 디자인 개선 및 피드 기능 고도화 및 UI 개선

### DIFF
--- a/src/apis/teamspace/getTeamSpaceInformation.ts
+++ b/src/apis/teamspace/getTeamSpaceInformation.ts
@@ -1,9 +1,19 @@
 import { axiosInstance } from '@apis/axiosInstance';
 import { END_POINTS } from '@constants/api';
 
-const getTeamSpaceInformation = async (teamCode: string) => {
+interface RequestConfig {
+	authRequired?: boolean;
+}
+
+const getTeamSpaceInformation = async (
+	teamCode: string,
+	config: RequestConfig = { authRequired: true }
+) => {
 	const response = await axiosInstance.get(
-		`${END_POINTS.TEAMSPACE}?code=${teamCode}`
+		`${END_POINTS.TEAMSPACE}?code=${teamCode}`,
+		{
+			authRequired: config.authRequired,
+		}
 	);
 
 	return response.data.content;

--- a/src/components/Chat/ChatRoom/ChatRoomCreationModal/ChatRoomCreationModal.tsx
+++ b/src/components/Chat/ChatRoom/ChatRoomCreationModal/ChatRoomCreationModal.tsx
@@ -71,6 +71,7 @@ const ChatRoomCreationModal = ({
 					maxLength={15}
 					value={teamspaceName}
 					onChange={handleNameChange}
+					onEnterPress={handlCreateClick}
 				/>
 				<Flex height='14' align='center'>
 					{nameError && (

--- a/src/components/Feed/Attachments/Attachments.tsx
+++ b/src/components/Feed/Attachments/Attachments.tsx
@@ -27,10 +27,10 @@ const Attachments = ({ attachment }: AttachmentsProps) => {
 			<Profile
 				profile={filterImageURL(fileUrl)}
 				initial={name.charAt(0)}
-				avatarSize='lg'
+				avatarSize='mlg'
 				avatarShape='rect'
 				title={name}
-				titleSize='lg'
+				titleSize='md'
 				titleWeight='medium'
 				text={getUnitFormattedSize(size)}
 			/>

--- a/src/components/Feed/CommentInput/CommentInput.tsx
+++ b/src/components/Feed/CommentInput/CommentInput.tsx
@@ -34,17 +34,19 @@ const CommentInput = (props: CommentInputProps) => {
 	return (
 		<S.CommentInputContainer ref={commentRef}>
 			<Input
-				size='sm'
+				size='md'
 				border='underLine'
 				isError={false}
 				placeholder='댓글 달기...'
 				value={comment}
 				onChange={handleCommentChange}
+				onEnterPress={handleLeaveComment}
+				maxLength={250}
 			/>
 			<Button
-				label='등록'
+				label='작성'
 				variant='primary'
-				size='sm'
+				size='md'
 				disabled={!comment.trim().length}
 				onClick={handleLeaveComment}
 			/>

--- a/src/components/Feed/Comments/Comment.styled.ts
+++ b/src/components/Feed/Comments/Comment.styled.ts
@@ -1,0 +1,16 @@
+import { styled } from 'styled-components';
+import theme from '@styles/theme';
+
+export const CommentContainer = styled.div`
+	display: flex;
+	justify-content: space-between;
+	align-items: flex-start;
+	padding: ${theme.units.spacing.space12} 0;
+	border-radius: ${theme.units.radius.radius8};
+	width: 100%;
+	cursor: pointer;
+`;
+
+export const AvatarContainer = styled.div`
+	flex-shrink: 0;
+`;

--- a/src/components/Feed/Comments/Comment.tsx
+++ b/src/components/Feed/Comments/Comment.tsx
@@ -1,4 +1,8 @@
-import Profile from '@components/common/Profile/Profile';
+import Avatar from '@components/common/Avatar/Avatar';
+import Flex from '@components/common/Flex/Flex';
+import Icon from '@components/common/Icon/Icon';
+import Text from '@components/common/Text/Text';
+import * as S from './Comment.styled';
 
 interface Comment {
 	author: {
@@ -16,19 +20,36 @@ interface CommentsProps {
 
 const Comment = ({ comment }: CommentsProps) => {
 	const { author, content, createdAt } = comment;
+
 	return (
-		<Profile
-			profile={author.profileImageUrl}
-			initial={author.username.charAt(0)}
-			avatarSize='lg'
-			avatarShape='rect'
-			title={author.username}
-			titleSize='lg'
-			titleWeight='medium'
-			subTitle={createdAt}
-			text={content}
-			trailingIcon='Kebab'
-		/>
+		<S.CommentContainer>
+			<Flex gap='8' align='flex-start'>
+				<S.AvatarContainer>
+					<Avatar
+						profile={author.profileImageUrl}
+						initial={author.username.charAt(0)}
+						size='mlg'
+						shape='circle'
+					/>
+				</S.AvatarContainer>
+				<Flex direction='column' gap='8'>
+					<Flex align='center' gap='6'>
+						<Text size='md' weight='bold'>
+							{author.username}
+						</Text>
+						<Text size='md' weight='regular' color='tertiary'>
+							{createdAt}
+						</Text>
+					</Flex>
+					<Text size='md' weight='regular' color='primary'>
+						{content}
+					</Text>
+				</Flex>
+			</Flex>
+			<Flex gap='8' align='center'>
+				<Icon name='Kebab' size='sm' />
+			</Flex>
+		</S.CommentContainer>
 	);
 };
 

--- a/src/components/Feed/Detail/Normal/NormalDetail.styled.ts
+++ b/src/components/Feed/Detail/Normal/NormalDetail.styled.ts
@@ -25,6 +25,7 @@ export const FeedContainer = styled.div`
 export const DetailWrapper = styled.div`
 	${editorStyles}
 	margin-bottom: ${theme.units.spacing.space48};
+	width: 732px;
 	min-height: 150px;
 `;
 

--- a/src/components/Feed/Detail/Normal/NormalDetail.styled.ts
+++ b/src/components/Feed/Detail/Normal/NormalDetail.styled.ts
@@ -24,6 +24,8 @@ export const FeedContainer = styled.div`
 
 export const DetailWrapper = styled.div`
 	${editorStyles}
+	margin-bottom: ${theme.units.spacing.space48};
+	min-height: 150px;
 `;
 
 export const AttachmentWrapper = styled.div`

--- a/src/components/Feed/Detail/Normal/NormalDetail.tsx
+++ b/src/components/Feed/Detail/Normal/NormalDetail.tsx
@@ -49,7 +49,7 @@ const Feed = ({ feedData }: FeedProps) => {
 						})}
 					</S.SectionContainer>
 				)}
-				{comments.length !== 0 && (
+				{true && (
 					<S.SectionContainer>
 						<Flex direction='column' align='flex-start'>
 							<Text
@@ -68,12 +68,14 @@ const Feed = ({ feedData }: FeedProps) => {
 						})}
 					</S.SectionContainer>
 				)}
-				{userStatus && (
-					<CommentInput
-						teamspaceId={userStatus.profile.lastSeenTeamspaceId}
-						feedId={feedId}
-					/>
-				)}
+				<Flex direction='column' marginTop='8' marginBottom='48' grow='1'>
+					{userStatus && (
+						<CommentInput
+							teamspaceId={userStatus.profile.lastSeenTeamspaceId}
+							feedId={feedId}
+						/>
+					)}
+				</Flex>
 			</Flex>
 		</S.FeedContainer>
 	);

--- a/src/components/Post/Editor/Editor.styled.ts
+++ b/src/components/Post/Editor/Editor.styled.ts
@@ -2,22 +2,21 @@ import { styled } from 'styled-components';
 import { editorStyles } from '@styles/editorStyles';
 import theme from '@styles/theme';
 
-export const EditorContainer = styled.form`
+export const EditorContainer = styled.form<{ heightOffset?: number }>`
+	border-radius: 0;
 	display: flex;
 	flex-direction: column;
-	width: 680px;
-	min-height: 400px;
-	border-radius: 8px;
+	width: 100%;
 
 	.tiptap {
-		min-height: 400px;
-		max-height: 800px;
+		min-height: 230px;
+		max-height: ${({ heightOffset = 600 }) =>
+			`calc(100dvh - ${heightOffset}px)`};
 		overflow-y: auto;
 		padding: ${theme.units.spacing.space12};
 		padding-bottom: ${theme.units.spacing.space36};
 		border: 1px solid ${theme.color.border.primary};
 		border-top: none;
-
 		${editorStyles}
 	}
 `;

--- a/src/components/Post/Editor/Editor.tsx
+++ b/src/components/Post/Editor/Editor.tsx
@@ -1,4 +1,5 @@
 import { MutableRefObject } from 'react';
+import Flex from '@components/common/Flex/Flex';
 import EditorMenu from '@components/Post/EditorMenu/EditorMenu';
 import Image from '@tiptap/extension-image';
 import TextAlign from '@tiptap/extension-text-align';
@@ -11,9 +12,10 @@ import * as S from './Editor.styled';
 interface EditorProps {
 	editorRef: MutableRefObject<EditorType | null>;
 	appendImageFile: (file: File) => void;
+	heightOffset?: number;
 }
 
-const Editor = ({ editorRef, appendImageFile }: EditorProps) => {
+const Editor = ({ editorRef, appendImageFile, heightOffset }: EditorProps) => {
 	const editor = useEditor({
 		extensions: [
 			StarterKit.configure({
@@ -35,10 +37,12 @@ const Editor = ({ editorRef, appendImageFile }: EditorProps) => {
 	}
 
 	return (
-		<S.EditorContainer>
+		<Flex direction='column'>
 			<EditorMenu editor={editor} appendImageFile={appendImageFile} />
-			<EditorContent editor={editor} />
-		</S.EditorContainer>
+			<S.EditorContainer heightOffset={heightOffset}>
+				<EditorContent editor={editor} />
+			</S.EditorContainer>
+		</Flex>
 	);
 };
 

--- a/src/components/Post/NormalPost/NormalPost.styled.ts
+++ b/src/components/Post/NormalPost/NormalPost.styled.ts
@@ -8,6 +8,11 @@ export const NormalPostContainer = styled.form`
 	gap: ${theme.units.spacing.space32};
 `;
 
+export const EditorContainer = styled.div`
+	max-height: calc(100vh - 500px);
+	overflow-x: hidden;
+`;
+
 export const PostInput = styled.input`
 	font-size: ${theme.typography.fontSize.header.sm};
 	font-weight: ${theme.typography.fontWeight.semiBold};

--- a/src/components/Post/NormalPost/NormalPost.tsx
+++ b/src/components/Post/NormalPost/NormalPost.tsx
@@ -48,7 +48,9 @@ const NormalPost = () => {
 				value={title}
 				onChange={handleTitleChange}
 			/>
-			<Editor editorRef={editorRef} appendImageFile={appendImageFile} />
+			<S.EditorContainer>
+				<Editor editorRef={editorRef} appendImageFile={appendImageFile} />
+			</S.EditorContainer>
 			<FileUploadBox
 				files={attachmentFiles}
 				handleDragOver={handleDragOver}

--- a/src/components/common/Drawer/Drawer.styled.ts
+++ b/src/components/common/Drawer/Drawer.styled.ts
@@ -31,5 +31,4 @@ export const DrawerMenu = styled.div`
 export const DrawerContent = styled.div`
 	width: 100%;
 	background: ${theme.color.bg.primary};
-	padding-bottom: ${theme.units.spacing.space32};
 `;

--- a/src/components/common/Drawer/Drawer.tsx
+++ b/src/components/common/Drawer/Drawer.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import IconButton from '@components/common/IconButton/IconButton';
 import useOutsideClick from '@hooks/common/useOutSideClick';
@@ -14,6 +14,20 @@ const Drawer = ({ isOpen, onClose, children }: DrawerProps) => {
 	const ref = useOutsideClick({
 		onClickOutside: onClose,
 	});
+
+	const handleKeyDown = useCallback(
+		(event: KeyboardEvent) => {
+			if (event.key === 'Escape' && isOpen) {
+				onClose();
+			}
+		},
+		[isOpen, onClose]
+	);
+
+	useEffect(() => {
+		window.addEventListener('keydown', handleKeyDown);
+		return () => window.removeEventListener('keydown', handleKeyDown);
+	}, [handleKeyDown]);
 
 	useEffect(() => {
 		if (isOpen && ref.current) {

--- a/src/components/common/GNB/GNB.styled.ts
+++ b/src/components/common/GNB/GNB.styled.ts
@@ -13,8 +13,10 @@ export const GNBContainer = styled.div`
 
 export const LeftContainer = styled.div`
 	display: flex;
+	border-radius: ${theme.units.radius.radius8};
 	align-items: center;
 	gap: ${theme.units.spacing.space8};
+	cursor: pointer;
 
 	&:hover {
 		background-color: ${theme.color.bg.iSecondaryHover};
@@ -30,4 +32,5 @@ export const RightContainer = styled.div`
 export const ProfileContainer = styled.div`
 	display: flex;
 	gap: ${theme.units.spacing.space24};
+	cursor: pointer;
 `;

--- a/src/components/common/GNB/GNB.tsx
+++ b/src/components/common/GNB/GNB.tsx
@@ -112,10 +112,10 @@ const GNB = () => {
 						<Avatar
 							profile={lastSeenTeam.profileImageUrl}
 							initial={lastSeenTeam.name}
-							size='lg'
+							size='mlg'
 							shape='rect'
 						/>
-						<Heading size='md'>{lastSeenTeam.name}</Heading>
+						<Heading size='sm'>{lastSeenTeam.name}</Heading>
 						<Icon name='Updown' />
 					</S.LeftContainer>
 					{chatChannelsSubscribeRef &&

--- a/src/components/common/GNB/GNBMenu/GNBTeamSpace/GNBTeamSpace.syled.ts
+++ b/src/components/common/GNB/GNBMenu/GNBTeamSpace/GNBTeamSpace.syled.ts
@@ -19,6 +19,7 @@ export const TeamSpacesWrapper = styled.div`
 	display: flex;
 	flex-direction: column;
 	overflow-y: auto;
+	cursor: pointer;
 
 	max-height: ${MENU_HEIGHT};
 	padding-right: ${theme.units.spacing.space10};
@@ -40,6 +41,7 @@ export const FooterContainer = styled.button`
 	border: none;
 	background: none;
 	width: 100%;
+	cursor: pointer;
 
 	gap: ${theme.units.spacing.space8};
 

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -18,6 +18,7 @@ export interface InputWrapperProps {
 	value: string;
 	maxLength?: number;
 	onChange: React.ChangeEventHandler<HTMLInputElement>;
+	onEnterPress?: () => void;
 }
 
 const Input = forwardRef<
@@ -30,12 +31,30 @@ const Input = forwardRef<
 		isError,
 		trailingIcon,
 		trailingIconColor,
+		onEnterPress,
+		onChange,
 		...attributes
 	} = props;
 
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+		if (e.key === 'Enter' && !e.nativeEvent.isComposing && onEnterPress) {
+			e.preventDefault();
+			onEnterPress();
+			const event = {
+				target: { value: '' },
+			} as React.ChangeEvent<HTMLInputElement>;
+			onChange(event);
+		}
+	};
+
 	return (
 		<S.InputContainer size={size} border={border} isError={isError}>
-			<S.InputWrapper ref={ref} {...attributes} />
+			<S.InputWrapper
+				ref={ref}
+				onChange={onChange}
+				{...attributes}
+				onKeyDown={handleKeyDown}
+			/>
 			{trailingIcon && (
 				<Icon name={trailingIcon} size={size} color={trailingIconColor} />
 			)}

--- a/src/components/common/OauthButton/OauthButton.styled.ts
+++ b/src/components/common/OauthButton/OauthButton.styled.ts
@@ -8,6 +8,7 @@ export const OauthButtonWrapper = styled.button`
 	border-radius: 6px;
 	border: none;
 	background-color: none;
+	cursor: pointer;
 
 	svg {
 		position: absolute;

--- a/src/components/common/Profile/Profile.tsx
+++ b/src/components/common/Profile/Profile.tsx
@@ -9,7 +9,7 @@ import * as S from './Profile.styled';
 export interface ProfileProps {
 	profile: string | null;
 	initial: string;
-	avatarSize?: AvatarSize;
+	avatarSize?: AvatarSize | 'mlg';
 	avatarShape?: 'circle' | 'rect';
 	title: string;
 	titleSize?: fontSize;

--- a/src/components/common/Toast/Toast.styled.ts
+++ b/src/components/common/Toast/Toast.styled.ts
@@ -9,11 +9,19 @@ export const ToastWrapper = styled.div<toastWrapperProps>`
 	justify-content: center;
 	align-items: center;
 	gap: ${(props) => props.theme.units.spacing.space12};
-	height: ${(props) => props.theme.units.spacing.space32};
 	padding: ${(props) =>
-		`${props.theme.units.spacing.space12} ${props.theme.units.spacing.space16}`};
-	background-color: ${(props) => props.theme.color.bg.iInverseStrong};
-	border-radius: ${(props) => props.theme.units.radius.radius6};
+		`${props.theme.units.spacing.space14} ${props.theme.units.spacing.space20}`};
+
+	background-color: ${(props) => `${props.theme.color.bg.iInverseStrong}90`};
+
+	backdrop-filter: blur(8px);
+	-webkit-backdrop-filter: blur(8px);
+	border-radius: ${(props) => props.theme.units.radius.radius12};
 	box-shadow: ${(props) => props.theme.elevation.shadow.shadow8};
 	animation: ${(props) => (props.isActive ? fadeIn : fadeOut)} 0.4s ease-out;
+`;
+
+export const ToastTextWrapper = styled.div`
+	max-width: 500px;
+	line-height: 1.2;
 `;

--- a/src/components/common/Toast/Toast.tsx
+++ b/src/components/common/Toast/Toast.tsx
@@ -29,10 +29,12 @@ const Toast = (props: ToastProps) => {
 
 	return createPortal(
 		<S.ToastWrapper ref={ref} isActive={isActive}>
-			<Icon name={variant} size='md' />
-			<Text as='span' color='iInverse' size='md' weight='medium'>
-				{message}
-			</Text>
+			<Icon name={variant} size='lg' />
+			<S.ToastTextWrapper>
+				<Text as='span' color='iInverse' size='lg' weight='medium'>
+					{message}
+				</Text>
+			</S.ToastTextWrapper>
 		</S.ToastWrapper>,
 		document.getElementById('toast-container') as Element
 	);

--- a/src/components/common/ToastContainer/ToastContainer.styled.ts
+++ b/src/components/common/ToastContainer/ToastContainer.styled.ts
@@ -1,8 +1,8 @@
 import { styled } from 'styled-components';
 
 export const ToastContainerWrapper = styled.div`
-	position: absolute;
-	bottom: 40px;
+	position: fixed;
+	bottom: 50px;
 	display: flex;
 	flex-direction: column-reverse;
 	justify-content: center;

--- a/src/hooks/queries/useLoginMutation.tsx
+++ b/src/hooks/queries/useLoginMutation.tsx
@@ -31,11 +31,11 @@ const useLoginMutation = () => {
 
 			if (inviteUrl) {
 				window.sessionStorage.removeItem(INVITE_URL);
-				navigate(`${PATH.INVITE}${inviteUrl}`);
+				navigate(`${PATH.INVITE}${inviteUrl}`, { replace: true });
 			} else if (content.hasTeam) {
-				navigate(PATH.FEED);
+				navigate(PATH.FEED, { replace: true });
 			} else {
-				navigate(PATH.ENTRY);
+				navigate(PATH.ENTRY, { replace: true });
 			}
 		},
 		onError: (error) => {

--- a/src/hooks/queries/useOauthLoginMutation.tsx
+++ b/src/hooks/queries/useOauthLoginMutation.tsx
@@ -30,11 +30,11 @@ const useOauthLoginMutation = () => {
 
 			if (inviteUrl) {
 				window.sessionStorage.removeItem(INVITE_URL);
-				navigate(`${PATH.INVITE}${inviteUrl}`);
+				navigate(`${PATH.INVITE}${inviteUrl}`, { replace: true });
 			} else if (content.hasTeam) {
-				navigate(PATH.FEED);
+				navigate(PATH.FEED, { replace: true });
 			} else {
-				navigate(PATH.ENTRY);
+				navigate(PATH.ENTRY, { replace: true });
 			}
 		},
 		onError: (error) => {

--- a/src/hooks/queries/useParticipateTeamSpaceMutation.ts
+++ b/src/hooks/queries/useParticipateTeamSpaceMutation.ts
@@ -3,9 +3,11 @@ import getTeamSpaceInformation from '@apis/teamspace/getTeamSpaceInformation';
 import postParticipateTeamSpace from '@apis/teamspace/postParticipateTeamSpace';
 import postUserLastSeen from '@apis/user/postUserLastSeen';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import useToastStore from '@stores/toastStore';
 import { PATH } from '@constants/path';
 
 const useParticipateTeamSpaceMutation = () => {
+	const { makeToast } = useToastStore();
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
 
@@ -17,6 +19,10 @@ const useParticipateTeamSpaceMutation = () => {
 			}
 			postUserLastSeen(content.teamspaceId);
 			queryClient.invalidateQueries({ queryKey: ['userStatus'] });
+			makeToast(
+				`${content.teamspaceName} 팀스페이스에 참가했습니다.`,
+				'Success'
+			);
 			navigate(PATH.FEED);
 		},
 		onError: (error) => {

--- a/src/pages/LandingPage/LandingPage.tsx
+++ b/src/pages/LandingPage/LandingPage.tsx
@@ -1,6 +1,8 @@
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@components/common/Button/Button';
 import Text from '@components/common/Text/Text';
+import { ACCESS_TOKEN } from '@constants/api';
 import { PATH } from '@constants/path';
 import { collaBear } from '@assets/png';
 import { Colla } from '@assets/svg';
@@ -9,6 +11,16 @@ import * as S from './LandingPage.styled';
 const LandingPage = () => {
 	const navigate = useNavigate();
 
+	useEffect(() => {
+		const checkToken = () => {
+			const accessToken = localStorage.getItem(ACCESS_TOKEN);
+			if (accessToken) {
+				navigate(PATH.FEED, { replace: true });
+			}
+		};
+
+		checkToken();
+	}, [navigate]);
 	return (
 		<S.Container>
 			<S.ImageWrapper>

--- a/src/pages/SignInPage/SignInPage.styled.ts
+++ b/src/pages/SignInPage/SignInPage.styled.ts
@@ -67,3 +67,14 @@ export const OauthWrapper = styled.div`
 	flex-direction: column;
 	gap: ${theme.units.spacing.space12};
 `;
+
+export const InvitedTeamspaceInfo = styled.div`
+	display: flex;
+	flex-direction: column;
+	width: 400px;
+	border-radius: ${theme.units.radius.radius8};
+	border: 1px solid ${theme.color.border.tertiary};
+	padding: ${theme.units.spacing.space16} ${theme.units.spacing.space24};
+	margin-bottom: ${theme.units.spacing.space8};
+	gap: ${theme.units.spacing.space12};
+`;

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -3,6 +3,7 @@ import reset from 'styled-reset';
 import { GNB_HEIGHT } from '@styles/layout';
 
 const GlobalStyle = createGlobalStyle`
+  @import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css");
   ${reset}
 
   #root {


### PR DESCRIPTION
## 📌 관련 이슈

- closed: https://github.com/98OO/colla-frontend/issues/167
- 
## ✨ PR 세부 내용

- **GNB 디자인 리팩토링** (팀스페이스 이름 부분 팀스페이스 사진과 텍스트 크기 감소)
- **로그인 상태 관련 기능 개선**
  - **미로그인 상태에서 초대 메일 처리 로직 개선**
  (미 로그인 상태에서 초대 메일을 통해 들어온 경우, 로그인 이후 바로 참가처리 되도록 되어 있는데, 이 맥락을 사용자에게 알리도록 함, x 버튼을 눌러 로그인 이후 참가 처리 여부를 사용자가 결정 가능)
  - **로그인 관련 리다이렉션 처리 개선** (Oauth 등 로그인을 위한 임시 페이지로 돌아가는 것을 방지)

- **피드 UI/UX 개선**
  - **피드 상세보기 디자인 개선** (댓글  UI 개선, 댓글 입력란 디자인 수정, 여백 미세 조정)
  - **에디터 최대 크기 동적 조정** (WYSIWYG 에디터의 세로가 페이지를 넘어가지 않도록  maxHeight을 동적으로 가져갈 수 있도록 함)
  - **ESC 키 입력 시 피드 상세보기 off 기능 추가** (이제 Esc키 피드 상세보기를 끌 수 있음)
  - **Input 컴포넌트 특정 이벤트 처리 기능 추가** (Input 컴포넌트내에서 Enter  입력시 동작을 Optional로 지정 가능 -> 일부 사용자 입력란 사용성 개선)


- **기타 개선사항**
  - **토스트 메시지 표시 UI 개선** (토스트 메세지 UI를 개선)
  - **세부 피드 조회 시 내부 width 수정** (중앙 정렬)
  - **웹폰트 적용** (Pretendard 웹 폰트 사용하도록 설정)

## 📸 스크린샷
<img width="1430" alt="스크린샷 2024-11-19 오전 6 44 49" src="https://github.com/user-attachments/assets/05f09b61-a22f-439a-8656-2df99cb10f73">
<img width="842" alt="스크린샷 2024-11-19 오전 4 39 37" src="https://github.com/user-attachments/assets/a5eeab18-bab9-49e1-a8db-bae74c43a245">

