### PR TITLE
자료 수집 피드 조회 및 상세 페이지 구현

### DIFF
--- a/src/assets/svg/clock.svg
+++ b/src/assets/svg/clock.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12.0003 20.3334C16.6027 20.3334 20.3337 16.6024 20.3337 12C20.3337 7.39765 16.6027 3.66669 12.0003 3.66669C7.39795 3.66669 3.66699 7.39765 3.66699 12C3.66699 16.6024 7.39795 20.3334 12.0003 20.3334Z" stroke="stroke" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 7V12L15.3333 13.6667" stroke="stroke" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/svg/index.ts
+++ b/src/assets/svg/index.ts
@@ -56,3 +56,4 @@ export { ReactComponent as ChevronsLeft } from './chevrons-left.svg';
 export { ReactComponent as ChevronLeft } from './chevron-left.svg';
 export { ReactComponent as ChevronRight } from './chevron-right.svg';
 export { ReactComponent as PDF } from './PDFLogo.svg';
+export { ReactComponent as Clock } from './clock.svg';

--- a/src/components/Feed/CollectFeed/CollectFeed.styled.ts
+++ b/src/components/Feed/CollectFeed/CollectFeed.styled.ts
@@ -1,0 +1,57 @@
+import { styled } from 'styled-components';
+import { editorStyles } from '@styles/editorStyles';
+import { FEED_DETAIL_MAX_HEIGHT } from '@styles/layout';
+import theme from '@styles/theme';
+
+export const FeedContainer = styled.div`
+	display: flex;
+	flex-direction: column;
+	width: 680px;
+	padding: ${theme.units.spacing.space24} 0 ${theme.units.spacing.space8} 0;
+	border-radius: ${theme.units.radius.radius12};
+	box-shadow: ${theme.elevation.shadow.shadow4};
+	margin-bottom: ${theme.units.spacing.space32};
+`;
+
+export const CollectContainer = styled.div`
+	display: flex;
+	flex-direction: column;
+	padding: 0 ${theme.units.spacing.space24};
+	gap: ${theme.units.spacing.space24};
+`;
+
+export const DetailWrapper = styled.div<{ hasMoreButton: boolean }>`
+	${editorStyles}
+	padding: ${theme.units.spacing.space16} 0;
+	min-height: 150px;
+	max-height: ${FEED_DETAIL_MAX_HEIGHT}px;
+	position: relative;
+	overflow: hidden;
+
+	${({ hasMoreButton }) =>
+		hasMoreButton &&
+		`
+    &:after {
+      content: '';
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      width: 100%;
+      height: calc(20%);
+      background: linear-gradient(
+        to bottom,
+        transparent,
+        ${theme.color.bg.primary}
+      );
+      pointer-events: none;
+    }
+  `}
+`;
+
+export const CommentPreviewWrapper = styled.div`
+	display: flex;
+	margin-top: ${theme.units.spacing.space12};
+	margin-left: ${theme.units.spacing.space24};
+	margin-bottom: ${theme.units.spacing.space6};
+	gap: ${theme.units.spacing.space8};
+`;

--- a/src/components/Feed/CollectFeed/CollectFeed.tsx
+++ b/src/components/Feed/CollectFeed/CollectFeed.tsx
@@ -1,0 +1,206 @@
+import { useEffect, useRef, useState } from 'react';
+import { Button } from '@components/common/Button/Button';
+import Divider from '@components/common/Divider/Divider';
+import Drawer from '@components/common/Drawer/Drawer';
+import Flex from '@components/common/Flex/Flex';
+import Heading from '@components/common/Heading/Heading';
+import Icon from '@components/common/Icon/Icon';
+import IconButton from '@components/common/IconButton/IconButton';
+import Text from '@components/common/Text/Text';
+import SubTask from '@components/Feed/CollectFeed/SubTask/SubTask';
+import CollectDetail from '@components/Feed/Detail/Collect/CollectDetail';
+import FeedAuthor from '@components/Feed/FeedAuthors/FeedAuthor';
+import ProgressChip from '@components/Feed/ProgressChip/ProgressChip';
+import { getFormattedDate } from '@utils/getFormattedDate';
+import { FEED_DETAIL_MAX_HEIGHT } from '@styles/layout';
+import type { FeedData, CollectFeed } from '@type/feed';
+import * as S from './CollectFeed.styled';
+
+interface ActionButtonProps {
+	icon: 'Comment' | 'Attachment';
+	count: number;
+	onClick: () => void;
+	ariaLabel: string;
+}
+
+interface FeedProps {
+	feedData: CollectFeed;
+	isDetailOpen: boolean;
+	openDetail: () => void;
+	closeDetail: () => void;
+}
+
+const ActionButton = ({
+	icon,
+	count,
+	onClick,
+	ariaLabel,
+}: ActionButtonProps) => {
+	return (
+		<Flex align='center'>
+			<IconButton
+				icon={icon}
+				size='md'
+				color='secondary'
+				ariaLabel={ariaLabel}
+				onClick={onClick}
+			/>
+			<Text color='secondary' size='md' weight='medium'>
+				{count === 0 ? '0' : String(count)}
+			</Text>
+		</Flex>
+	);
+};
+
+const CommentPreview = ({ comments }: { comments: FeedData['comments'] }) => {
+	if (comments.length === 0) return null;
+
+	const commentsToShow =
+		comments.length === 1 ? comments.slice(-1) : comments.slice(-2);
+	return (
+		<Flex direction='column' gap='8' marginBottom='10'>
+			{commentsToShow.map((comment) => (
+				<Flex key={comment.id} gap='6'>
+					<Text size='md' weight='semiBold'>
+						{comment.author.username}
+					</Text>
+					<Text size='md' weight='regular'>
+						{comment.content}
+					</Text>
+				</Flex>
+			))}
+		</Flex>
+	);
+};
+
+const CollectFeed = ({
+	feedData,
+	isDetailOpen,
+	openDetail,
+	closeDetail,
+}: FeedProps) => {
+	const { author, title, createdAt, details, attachments, comments } = feedData;
+	const [showMoreButton, setShowMoreButton] = useState(false);
+	const detailRef = useRef<HTMLDivElement | null>(null);
+
+	useEffect(() => {
+		const observer = new ResizeObserver(() => {
+			if (!detailRef.current) return;
+
+			setShowMoreButton(
+				detailRef.current.scrollHeight > FEED_DETAIL_MAX_HEIGHT
+			);
+		});
+
+		if (detailRef.current) {
+			observer.observe(detailRef.current);
+		}
+
+		return () => {
+			observer.disconnect();
+		};
+	}, [details?.content]);
+
+	return (
+		<S.FeedContainer>
+			<S.CollectContainer>
+				<FeedAuthor
+					profile={author.profileImageUrl}
+					initial={author.username.charAt(0)}
+					title={author.username}
+					createdAt={getFormattedDate(createdAt, 'feed')}
+					tag={author?.tag?.name || ''}
+				/>
+				<Flex direction='column' gap='12'>
+					<Heading size='xs'>{title}</Heading>
+					<Divider size='sm' />
+					<Flex direction='column' gap='16'>
+						<Flex align='center' gap='14'>
+							<Icon name='Clock' />
+							<Flex gap='8'>
+								<ProgressChip type='PENDING' status={!details.isClosed} />
+								<ProgressChip type='COMPLETED' status={details.isClosed} />
+							</Flex>
+						</Flex>
+						<Flex align='center' gap='14'>
+							<Icon name='Calendar' />
+							<Text size='md' weight='regular'>
+								{getFormattedDate(createdAt, 'detail')}
+							</Text>
+						</Flex>
+						<Flex align='center' gap='14'>
+							<Icon name='Calendar' />
+							{details.dueAt && (
+								<Text size='md' weight='regular'>
+									{`${getFormattedDate(details.dueAt, 'detail')} 까지`}
+								</Text>
+							)}
+						</Flex>
+						{details && (
+							<S.DetailWrapper ref={detailRef} hasMoreButton={showMoreButton}>
+								<div
+									dangerouslySetInnerHTML={{ __html: details.content || '' }}
+								/>
+							</S.DetailWrapper>
+						)}
+						{showMoreButton && (
+							<Flex>
+								<Button
+									type='button'
+									size='sm'
+									variant='secondary'
+									label='더보기'
+									onClick={openDetail}
+								/>
+							</Flex>
+						)}
+					</Flex>
+					<Flex direction='column' gap='12'>
+						<Flex align='center' gap='6'>
+							<Text size='lg' weight='semiBold'>
+								하위업무
+							</Text>
+							<Text size='lg' weight='semiBold' color='tertiary'>
+								{details.responses.length.toString()}
+							</Text>
+						</Flex>
+						<Flex direction='column'>
+							{details.responses.map((task) => (
+								<SubTask subTaskData={task} onClick={openDetail} />
+							))}
+						</Flex>
+					</Flex>
+				</Flex>
+				{isDetailOpen && (
+					<Drawer isOpen={isDetailOpen} onClose={closeDetail}>
+						<CollectDetail feedData={feedData} />
+					</Drawer>
+				)}
+			</S.CollectContainer>
+			<Flex direction='column' paddingRight='24' paddingLeft='24'>
+				<Divider size='sm' padding={16} />
+			</Flex>
+			<Flex direction='row' marginLeft='18' gap='8'>
+				<ActionButton
+					icon='Comment'
+					count={comments.length}
+					onClick={openDetail}
+					ariaLabel='댓글'
+				/>
+				{attachments.length > 0 && (
+					<ActionButton
+						icon='Attachment'
+						count={attachments.length}
+						onClick={openDetail}
+						ariaLabel='첨부파일'
+					/>
+				)}
+			</Flex>
+			<S.CommentPreviewWrapper>
+				<CommentPreview comments={comments} />
+			</S.CommentPreviewWrapper>
+		</S.FeedContainer>
+	);
+};
+
+export default CollectFeed;

--- a/src/components/Feed/CollectFeed/SubTask/SubTask.styled.ts
+++ b/src/components/Feed/CollectFeed/SubTask/SubTask.styled.ts
@@ -1,0 +1,17 @@
+import { styled } from 'styled-components';
+import theme from '@styles/theme';
+
+export const SubTaskContainer = styled.div`
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+
+	padding: ${theme.units.spacing.space6} ${theme.units.spacing.space12};
+	border: 1px solid ${theme.color.border.tertiary};
+	border-radius: ${theme.units.radius.radius4};
+
+	&:hover {
+		background-color: ${theme.color.bg.iSecondaryHover};
+		cursor: pointer;
+	}
+`;

--- a/src/components/Feed/CollectFeed/SubTask/SubTask.tsx
+++ b/src/components/Feed/CollectFeed/SubTask/SubTask.tsx
@@ -1,0 +1,44 @@
+import Avatar from '@components/common/Avatar/Avatar';
+import Flex from '@components/common/Flex/Flex';
+import Text from '@components/common/Text/Text';
+import ProgressChip from '@components/Feed/ProgressChip/ProgressChip';
+import { getFormattedDate } from '@utils/getFormattedDate';
+import type { CollectResponse } from '@type/feed';
+import * as S from './SubTask.styled';
+
+interface SubTaskProps {
+	subTaskData: CollectResponse;
+	onClick: () => void;
+}
+
+const SubTask = ({ subTaskData, onClick }: SubTaskProps) => {
+	const { title, status, updatedAt, author } = subTaskData;
+
+	return (
+		<S.SubTaskContainer onClick={onClick}>
+			<Flex align='center' gap='10'>
+				<ProgressChip type={status} />
+				{title && (
+					<Text size='lg' weight='medium'>
+						{title}
+					</Text>
+				)}
+			</Flex>
+			<Flex align='center' gap='14'>
+				{status !== 'PENDING' && (
+					<Text size='md' weight='regular' color='tertiary'>
+						{getFormattedDate(updatedAt, 'collectDate')}
+					</Text>
+				)}
+				<Avatar
+					profile={author.profileImageUrl}
+					initial={author.username.charAt(0)}
+					size='md'
+					shape='circle'
+				/>
+			</Flex>
+		</S.SubTaskContainer>
+	);
+};
+
+export default SubTask;

--- a/src/components/Feed/Detail/Collect/CollectDetail.styled.ts
+++ b/src/components/Feed/Detail/Collect/CollectDetail.styled.ts
@@ -1,0 +1,34 @@
+import { styled } from 'styled-components';
+import { editorStyles } from '@styles/editorStyles';
+import theme from '@styles/theme';
+
+export const FeedContainer = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: ${theme.units.spacing.space24};
+	height: calc(100% - 64px);
+	overflow: auto;
+	padding: ${theme.units.spacing.space12} ${theme.units.spacing.space32};
+	padding-bottom: 0;
+	overflow-x: hidden;
+
+	&::-webkit-scrollbar {
+		width: 4px;
+	}
+
+	&::-webkit-scrollbar-thumb {
+		border-radius: ${theme.units.radius.radius20};
+		background: ${theme.color.border.secondary};
+	}
+`;
+
+export const DetailWrapper = styled.div`
+	${editorStyles}
+`;
+
+export const SectionContainer = styled.div`
+	display: flex;
+	flex-direction: column;
+	padding: ${theme.units.spacing.space12} 0;
+	gap: ${theme.units.spacing.space12};
+`;

--- a/src/components/Feed/Detail/Collect/CollectDetail.tsx
+++ b/src/components/Feed/Detail/Collect/CollectDetail.tsx
@@ -1,0 +1,129 @@
+import { useState } from 'react';
+import { Button } from '@components/common/Button/Button';
+import Divider from '@components/common/Divider/Divider';
+import Flex from '@components/common/Flex/Flex';
+import Heading from '@components/common/Heading/Heading';
+import Icon from '@components/common/Icon/Icon';
+import Text from '@components/common/Text/Text';
+import SubTask from '@components/Feed/CollectFeed/SubTask/SubTask';
+import CommentInput from '@components/Feed/CommentInput/CommentInput';
+import Comment from '@components/Feed/Comments/Comment';
+import FeedAuthor from '@components/Feed/FeedAuthors/FeedAuthor';
+import ProgressChip from '@components/Feed/ProgressChip/ProgressChip';
+import useUserStatusQuery from '@hooks/queries/useUserStatusQuery';
+import { getFormattedDate } from '@utils/getFormattedDate';
+import type { CollectFeed, Author } from '@type/feed';
+import * as S from './CollectDetail.styled';
+
+interface FeedProps {
+	feedData: CollectFeed;
+}
+
+const CollectDetail = ({ feedData }: FeedProps) => {
+	const { feedId, author, title, createdAt, details, comments } = feedData;
+	const { userStatus } = useUserStatusQuery();
+	const [selectSubTask, setSelectSubTask] = useState<Author | null>(null);
+
+	return (
+		<S.FeedContainer>
+			<Flex align='center'>
+				<Button
+					label='자료 수집 상세 페이지'
+					variant='text'
+					size='md'
+					onClick={() => setSelectSubTask(null)}
+				/>
+				{selectSubTask && (
+					<Flex align='center' gap='8'>
+						<Icon name='ChevronRight' />
+						<Text size='md' weight='semiBold' color='iSecondary'>
+							{selectSubTask.username}
+						</Text>
+					</Flex>
+				)}
+			</Flex>
+			<FeedAuthor
+				profile={author.profileImageUrl}
+				initial={author.username.charAt(0)}
+				title={author.username}
+				createdAt={getFormattedDate(createdAt, 'detail')}
+				tag={author?.tag?.name || ''}
+			/>
+			<Flex direction='column' gap='12'>
+				<Heading size='xs'>{title}</Heading>
+				<Divider size='sm' />
+				<Flex direction='column' gap='16' marginBottom='20'>
+					<Flex align='center' gap='14'>
+						<Icon name='Clock' />
+						<Flex gap='8'>
+							<ProgressChip type='PENDING' status={!details.isClosed} />
+							<ProgressChip type='COMPLETED' status={details.isClosed} />
+						</Flex>
+					</Flex>
+					<Flex align='center' gap='14'>
+						<Icon name='Calendar' />
+						<Text size='md' weight='regular'>
+							{getFormattedDate(createdAt, 'detail')}
+						</Text>
+					</Flex>
+					<Flex align='center' gap='14'>
+						<Icon name='Calendar' />
+						{details.dueAt && (
+							<Text size='md' weight='regular'>
+								{`${getFormattedDate(details.dueAt, 'detail')} 까지`}
+							</Text>
+						)}
+					</Flex>
+					<S.DetailWrapper>
+						<div dangerouslySetInnerHTML={{ __html: details.content || '' }} />
+					</S.DetailWrapper>
+				</Flex>
+				<Flex direction='column' gap='12'>
+					<Flex align='center' gap='6'>
+						<Text size='lg' weight='semiBold'>
+							하위업무
+						</Text>
+						<Text size='lg' weight='semiBold' color='tertiary'>
+							{details.responses.length.toString()}
+						</Text>
+					</Flex>
+					<Flex direction='column'>
+						{details.responses.map((task) => (
+							<SubTask
+								subTaskData={task}
+								onClick={() => setSelectSubTask(task.author)}
+							/>
+						))}
+					</Flex>
+				</Flex>
+			</Flex>
+			{comments.length !== 0 && (
+				<S.SectionContainer>
+					<Flex direction='column' align='flex-start'>
+						<Text
+							size='md'
+							weight='medium'
+							color='tertiary'>{`댓글 ${comments.length}개`}</Text>
+					</Flex>
+					<Divider size='sm' />
+					{comments.map((comment) => {
+						return (
+							<Flex direction='column' gap='8'>
+								<Comment comment={comment} />
+								<Divider size='sm' />
+							</Flex>
+						);
+					})}
+				</S.SectionContainer>
+			)}
+			{userStatus && (
+				<CommentInput
+					teamspaceId={userStatus.profile.lastSeenTeamspaceId}
+					feedId={feedId}
+				/>
+			)}
+		</S.FeedContainer>
+	);
+};
+
+export default CollectDetail;

--- a/src/components/Feed/ProgressChip/ProgressChip.styled.ts
+++ b/src/components/Feed/ProgressChip/ProgressChip.styled.ts
@@ -1,0 +1,33 @@
+import styled, { css } from 'styled-components';
+import theme from '@styles/theme';
+import type { progressChipProps } from './ProgressChip';
+
+const progressBackGroundColor = {
+	DEFALUT: `${theme.color.bg.secondary}`,
+	REQUEST: '#02B1FD',
+	PENDING: '#00B01B',
+	FEEDBACK: '#FE7901',
+	COMPLETED: '#41299E',
+};
+
+export const ProgressChipContainer = styled.div.withConfig({
+	shouldForwardProp: (prop) => !['status', 'type'].includes(prop),
+})<progressChipProps>`
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	width: 64px;
+	height: 24px;
+
+	font-size: ${theme.typography.fontSize.body.sm};
+	font-weight: ${theme.typography.fontWeight.semiBold};
+	border-radius: ${theme.units.radius.radius16};
+
+	${({ type, status }) => css`
+		background-color: ${status
+			? progressBackGroundColor[type]
+			: progressBackGroundColor.DEFALUT};
+
+		color: ${status ? theme.color.text.iInverse : theme.color.text.secondary};
+	`}
+`;

--- a/src/components/Feed/ProgressChip/ProgressChip.tsx
+++ b/src/components/Feed/ProgressChip/ProgressChip.tsx
@@ -9,7 +9,7 @@ type progressType =
 
 export interface progressChipProps {
 	type: progressType;
-	status: boolean;
+	status?: boolean;
 }
 
 const getProgressText = (type: progressType) => {
@@ -28,7 +28,7 @@ const getProgressText = (type: progressType) => {
 };
 
 const ProgressChip = (props: progressChipProps) => {
-	const { type, status } = props;
+	const { type, status = true } = props;
 
 	return (
 		<S.ProgressChipContainer type={type} status={status}>

--- a/src/components/Feed/ProgressChip/ProgressChip.tsx
+++ b/src/components/Feed/ProgressChip/ProgressChip.tsx
@@ -1,0 +1,40 @@
+import * as S from './ProgressChip.styled';
+
+type progressType =
+	| 'DEFALUT'
+	| 'REQUEST'
+	| 'PENDING'
+	| 'FEEDBACK'
+	| 'COMPLETED';
+
+export interface progressChipProps {
+	type: progressType;
+	status: boolean;
+}
+
+const getProgressText = (type: progressType) => {
+	switch (type) {
+		case 'REQUEST':
+			return '요청';
+		case 'PENDING':
+			return '진행';
+		case 'FEEDBACK':
+			return '피드백';
+		case 'COMPLETED':
+			return '완료';
+		default:
+			return '';
+	}
+};
+
+const ProgressChip = (props: progressChipProps) => {
+	const { type, status } = props;
+
+	return (
+		<S.ProgressChipContainer type={type} status={status}>
+			{getProgressText(type)}
+		</S.ProgressChipContainer>
+	);
+};
+
+export default ProgressChip;

--- a/src/pages/FeedPage/FeedPage.tsx
+++ b/src/pages/FeedPage/FeedPage.tsx
@@ -3,6 +3,7 @@ import InfiniteScroll from 'react-infinite-scroller';
 import Divider from '@components/common/Divider/Divider';
 import Heading from '@components/common/Heading/Heading';
 import Select from '@components/common/Select/Select';
+import CollectFeed from '@components/Feed/CollectFeed/CollectFeed';
 import Feed from '@components/Feed/Feed';
 import useMeasureWidth from '@hooks/common/useMeasureWidth';
 import useFeedDrawer from '@hooks/post/useFeedDrawer';
@@ -82,15 +83,29 @@ const FeedPage = () => {
 						const sanitizedFeeds = getSanitizedFeeds(pageData.content.feeds);
 
 						return sanitizedFeeds.map((feedData: FeedData) => {
-							const { feedId } = feedData;
+							const { feedId, feedType } = feedData;
+
 							return (
-								<Feed
-									key={feedId}
-									feedData={feedData}
-									isDetailOpen={isDrawerOpen(feedId)}
-									openDetail={() => openDrawer(feedId)}
-									closeDetail={closeDrawer}
-								/>
+								<>
+									{feedType === 'NORMAL' && (
+										<Feed
+											key={feedId}
+											feedData={feedData}
+											isDetailOpen={isDrawerOpen(feedId)}
+											openDetail={() => openDrawer(feedId)}
+											closeDetail={closeDrawer}
+										/>
+									)}
+									{feedType === 'COLLECT' && (
+										<CollectFeed
+											key={feedId}
+											feedData={feedData}
+											isDetailOpen={isDrawerOpen(feedId)}
+											openDetail={() => openDrawer(feedId)}
+											closeDetail={closeDrawer}
+										/>
+									)}
+								</>
 							);
 						});
 					})}

--- a/src/types/feed.ts
+++ b/src/types/feed.ts
@@ -70,7 +70,7 @@ interface NormalFeed extends FeedBase {
 	details: NormalDetails;
 }
 
-interface CollectFeed extends FeedBase {
+export interface CollectFeed extends FeedBase {
 	feedType: 'COLLECT';
 	details: CollectDetails;
 }

--- a/src/types/feed.ts
+++ b/src/types/feed.ts
@@ -6,7 +6,7 @@ export type FeedMenuType = 'normal' | 'collect' | 'scheduling'; // | 'vote'
 
 export type SelectType = keyof typeof FEED_SELECT_MAP;
 
-interface Author {
+export interface Author {
 	id: number;
 	profileImageUrl: string | null;
 	username: string;

--- a/src/types/feed.ts
+++ b/src/types/feed.ts
@@ -41,7 +41,7 @@ interface NormalDetails {
 	content: string | null;
 }
 
-interface CollectResponse {
+export interface CollectResponse {
 	title: string | null;
 	status: 'PENDING' | 'COMPLETED';
 	updatedAt: string;

--- a/src/utils/getFormattedDate.ts
+++ b/src/utils/getFormattedDate.ts
@@ -5,7 +5,8 @@ type FormatDateType =
 	| 'feed'
 	| 'detail'
 	| 'fullDateWithToday'
-	| 'documentDate';
+	| 'documentDate'
+	| 'collectDate';
 
 export const getFormattedDate = (
 	dateString: string | Date,
@@ -108,6 +109,16 @@ export const getFormattedDate = (
 
 		case 'documentDate':
 			return `${targetDate.getFullYear()}.${(targetDate.getMonth() + 1).toString().padStart(2, '0')}.${targetDate.getDate().toString().padStart(2, '0')}`;
+
+		case 'collectDate': {
+			const year = targetDate.getFullYear();
+			const month = String(targetDate.getMonth() + 1).padStart(2, '0');
+			const day = String(targetDate.getDate()).padStart(2, '0');
+			const weekDays = ['일', '월', '화', '수', '목', '금', '토'];
+			const dayOfWeek = weekDays[targetDate.getDay()];
+
+			return `${year}-${month}-${day} (${dayOfWeek})`;
+		}
 
 		default:
 			return '';


### PR DESCRIPTION
## 📌 관련 이슈

- closed: https://github.com/98OO/colla-frontend/issues/166

## ✨ PR 세부 내용

- 피드 페이지에서 자료 수집 피드 조회 기능 구현
- 자료 수집 피드 상세 조회 페이지 기능 구현
- 자료 수집 피드 하위업무 컴포넌트 구현
- 진행 상태를 나타내는 ProgressChip 컴포넌트 구현

## 📸 스크린샷(선택)

![image](https://github.com/user-attachments/assets/76133223-0756-4d2a-900a-ce870a23babf)

![image](https://github.com/user-attachments/assets/b02fcc07-e29b-4d28-b797-fa1e91670937)


## ✅ 리뷰 요구사항(선택)

- 자료 수집 피드를 한눈에 보기 위해 위 스크린샷은 화면 축소 후 캡처한 화면입니다.
