### PR TITLE
자료 수집 피드 하위 업무 조회 및 수정 페이지 구현

### DIFF
--- a/src/apis/Feed/Collect/getCollectSubTask.ts
+++ b/src/apis/Feed/Collect/getCollectSubTask.ts
@@ -1,0 +1,17 @@
+import { axiosInstance } from '@apis/axiosInstance';
+import { END_POINTS } from '@constants/api';
+import type { SubTaskResponse } from '@type/feed';
+
+const getCollectSubTask = async (
+	teamspaceId: number,
+	feedId: number,
+	userId: number
+): Promise<SubTaskResponse> => {
+	const response = await axiosInstance.get(
+		`${END_POINTS.GET_COLLECT_SUB_TASK(teamspaceId, feedId, userId)}`
+	);
+
+	return response.data.content;
+};
+
+export default getCollectSubTask;

--- a/src/apis/Feed/Collect/patchCollectSubTask.ts
+++ b/src/apis/Feed/Collect/patchCollectSubTask.ts
@@ -1,0 +1,28 @@
+import { axiosInstance } from '@apis/axiosInstance';
+import { END_POINTS } from '@constants/api';
+
+export interface CollectSubTaskParams {
+	teamspaceId: number | undefined;
+	feedId: number;
+	title: string | null;
+	content: string | null;
+}
+
+const patchCollectSubTask = async ({
+	teamspaceId,
+	feedId,
+	title,
+	content,
+}: CollectSubTaskParams) => {
+	const response = await axiosInstance.patch(
+		`${END_POINTS.PATCH_COLLECT_SUB_TASK(teamspaceId!, feedId)}`,
+		{
+			title,
+			content,
+		}
+	);
+
+	return response.data;
+};
+
+export default patchCollectSubTask;

--- a/src/components/Feed/Detail/Collect/CollectDetail.tsx
+++ b/src/components/Feed/Detail/Collect/CollectDetail.tsx
@@ -8,6 +8,7 @@ import Text from '@components/common/Text/Text';
 import SubTask from '@components/Feed/CollectFeed/SubTask/SubTask';
 import CommentInput from '@components/Feed/CommentInput/CommentInput';
 import Comment from '@components/Feed/Comments/Comment';
+import SubTaskDetail from '@components/Feed/Detail/SubTask/SubTaskDetail';
 import FeedAuthor from '@components/Feed/FeedAuthors/FeedAuthor';
 import ProgressChip from '@components/Feed/ProgressChip/ProgressChip';
 import useUserStatusQuery from '@hooks/queries/useUserStatusQuery';
@@ -34,7 +35,7 @@ const CollectDetail = ({ feedData }: FeedProps) => {
 					onClick={() => setSelectSubTask(null)}
 				/>
 				{selectSubTask && (
-					<Flex align='center' gap='8'>
+					<Flex align='center' gap='10'>
 						<Icon name='ChevronRight' />
 						<Text size='md' weight='semiBold' color='iSecondary'>
 							{selectSubTask.username}
@@ -42,85 +43,93 @@ const CollectDetail = ({ feedData }: FeedProps) => {
 					</Flex>
 				)}
 			</Flex>
-			<FeedAuthor
-				profile={author.profileImageUrl}
-				initial={author.username.charAt(0)}
-				title={author.username}
-				createdAt={getFormattedDate(createdAt, 'detail')}
-				tag={author?.tag?.name || ''}
-			/>
-			<Flex direction='column' gap='12'>
-				<Heading size='xs'>{title}</Heading>
-				<Divider size='sm' />
-				<Flex direction='column' gap='16' marginBottom='20'>
-					<Flex align='center' gap='14'>
-						<Icon name='Clock' />
-						<Flex gap='8'>
-							<ProgressChip type='PENDING' status={!details.isClosed} />
-							<ProgressChip type='COMPLETED' status={details.isClosed} />
+			{selectSubTask ? (
+				<SubTaskDetail subTaskAuthor={selectSubTask} feedId={feedId} />
+			) : (
+				<>
+					<FeedAuthor
+						profile={author.profileImageUrl}
+						initial={author.username.charAt(0)}
+						title={author.username}
+						createdAt={getFormattedDate(createdAt, 'detail')}
+						tag={author?.tag?.name || ''}
+					/>
+					<Flex direction='column' gap='12'>
+						<Heading size='xs'>{title}</Heading>
+						<Divider size='sm' />
+						<Flex direction='column' gap='16' marginBottom='20'>
+							<Flex align='center' gap='14'>
+								<Icon name='Clock' />
+								<Flex gap='8'>
+									<ProgressChip type='PENDING' status={!details.isClosed} />
+									<ProgressChip type='COMPLETED' status={details.isClosed} />
+								</Flex>
+							</Flex>
+							<Flex align='center' gap='14'>
+								<Icon name='Calendar' />
+								<Text size='md' weight='regular'>
+									{getFormattedDate(createdAt, 'detail')}
+								</Text>
+							</Flex>
+							<Flex align='center' gap='14'>
+								<Icon name='Calendar' />
+								{details.dueAt && (
+									<Text size='md' weight='regular'>
+										{`${getFormattedDate(details.dueAt, 'detail')} 까지`}
+									</Text>
+								)}
+							</Flex>
+							<S.DetailWrapper>
+								<div
+									dangerouslySetInnerHTML={{ __html: details.content || '' }}
+								/>
+							</S.DetailWrapper>
+						</Flex>
+						<Flex direction='column' gap='12'>
+							<Flex align='center' gap='6'>
+								<Text size='lg' weight='semiBold'>
+									하위 업무
+								</Text>
+								<Text size='lg' weight='semiBold' color='tertiary'>
+									{details.responses.length.toString()}
+								</Text>
+							</Flex>
+							<Flex direction='column'>
+								{details.responses.map((task) => (
+									<SubTask
+										subTaskData={task}
+										onClick={() => setSelectSubTask(task.author)}
+									/>
+								))}
+							</Flex>
 						</Flex>
 					</Flex>
-					<Flex align='center' gap='14'>
-						<Icon name='Calendar' />
-						<Text size='md' weight='regular'>
-							{getFormattedDate(createdAt, 'detail')}
-						</Text>
-					</Flex>
-					<Flex align='center' gap='14'>
-						<Icon name='Calendar' />
-						{details.dueAt && (
-							<Text size='md' weight='regular'>
-								{`${getFormattedDate(details.dueAt, 'detail')} 까지`}
-							</Text>
-						)}
-					</Flex>
-					<S.DetailWrapper>
-						<div dangerouslySetInnerHTML={{ __html: details.content || '' }} />
-					</S.DetailWrapper>
-				</Flex>
-				<Flex direction='column' gap='12'>
-					<Flex align='center' gap='6'>
-						<Text size='lg' weight='semiBold'>
-							하위업무
-						</Text>
-						<Text size='lg' weight='semiBold' color='tertiary'>
-							{details.responses.length.toString()}
-						</Text>
-					</Flex>
-					<Flex direction='column'>
-						{details.responses.map((task) => (
-							<SubTask
-								subTaskData={task}
-								onClick={() => setSelectSubTask(task.author)}
-							/>
-						))}
-					</Flex>
-				</Flex>
-			</Flex>
-			{comments.length !== 0 && (
-				<S.SectionContainer>
-					<Flex direction='column' align='flex-start'>
-						<Text
-							size='md'
-							weight='medium'
-							color='tertiary'>{`댓글 ${comments.length}개`}</Text>
-					</Flex>
-					<Divider size='sm' />
-					{comments.map((comment) => {
-						return (
-							<Flex direction='column' gap='8'>
-								<Comment comment={comment} />
-								<Divider size='sm' />
+					{comments.length !== 0 && (
+						<S.SectionContainer>
+							<Flex direction='column' align='flex-start'>
+								<Text
+									size='md'
+									weight='medium'
+									color='tertiary'>{`댓글 ${comments.length}개`}</Text>
 							</Flex>
-						);
-					})}
-				</S.SectionContainer>
-			)}
-			{userStatus && (
-				<CommentInput
-					teamspaceId={userStatus.profile.lastSeenTeamspaceId}
-					feedId={feedId}
-				/>
+							<Divider size='sm' />
+							{comments.map((comment) => {
+								return (
+									<Flex direction='column' gap='8'>
+										<Comment comment={comment} />
+										<Divider size='sm' />
+									</Flex>
+								);
+							})}
+						</S.SectionContainer>
+					)}
+					{userStatus && (
+						<CommentInput
+							teamspaceId={userStatus.profile.lastSeenTeamspaceId}
+							feedId={feedId}
+						/>
+					)}
+				</>
 			)}
 		</S.FeedContainer>
 	);

--- a/src/components/Feed/Detail/SubTask/SubTaskDetail.styled.ts
+++ b/src/components/Feed/Detail/SubTask/SubTaskDetail.styled.ts
@@ -1,0 +1,24 @@
+import { styled } from 'styled-components';
+import { editorStyles } from '@styles/editorStyles';
+import theme from '@styles/theme';
+
+export const SubTaskPostContainer = styled.form`
+	display: flex;
+	flex-direction: column;
+	width: 680px;
+	gap: ${theme.units.spacing.space32};
+`;
+
+export const PostInput = styled.input`
+	font-size: ${theme.typography.fontSize.header.sm};
+	font-weight: ${theme.typography.fontWeight.semiBold};
+	border: none;
+	outline: none;
+`;
+
+export const DetailWrapper = styled.div`
+	${editorStyles}
+	margin-bottom: ${theme.units.spacing.space48};
+	width: 732px;
+	min-height: 150px;
+`;

--- a/src/components/Feed/Detail/SubTask/SubTaskDetail.tsx
+++ b/src/components/Feed/Detail/SubTask/SubTaskDetail.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from 'react';
+import { Button } from '@components/common/Button/Button';
+import Divider from '@components/common/Divider/Divider';
+import Flex from '@components/common/Flex/Flex';
+import Heading from '@components/common/Heading/Heading';
+import FeedAuthor from '@components/Feed/FeedAuthors/FeedAuthor';
+import Editor from '@components/Post/Editor/Editor';
+import usePostEditor from '@hooks/post/usePostEditor';
+import useCollectSubTaskMutation from '@hooks/queries/Feed/Collect/useCollectSubTaskMutation';
+import useCollectSubTaskQuery from '@hooks/queries/Feed/Collect/useCollectSubTaskQuery';
+import useUserStatusQuery from '@hooks/queries/useUserStatusQuery';
+import { getFormattedDate } from '@utils/getFormattedDate';
+import type { Author } from '@type/feed';
+import * as S from './SubTaskDetail.styled';
+
+interface SubTaskPostProps {
+	subTaskAuthor: Author;
+	feedId: number;
+}
+
+const SubTaskDetail = ({ subTaskAuthor, feedId }: SubTaskPostProps) => {
+	const { id } = subTaskAuthor;
+	const { editorRef, appendImageFile } = usePostEditor();
+	const { userStatus } = useUserStatusQuery();
+	const { subTask } = useCollectSubTaskQuery(
+		userStatus?.profile.lastSeenTeamspaceId,
+		feedId,
+		id
+	);
+	const [title, setTitle] = useState<string | null>(null);
+	const { mutateCollectSubTask } = useCollectSubTaskMutation(
+		userStatus?.profile.lastSeenTeamspaceId,
+		feedId
+	);
+
+	useEffect(() => {
+		if (subTask) setTitle(subTask.title);
+	}, [subTask]);
+
+	const handleTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+		setTitle(event.target.value);
+	};
+
+	const handleSubmitSubTask = async () => {
+		if (editorRef.current && editorRef.current.getHTML() !== undefined) {
+			const content = editorRef.current.getHTML();
+
+			await mutateCollectSubTask({
+				teamspaceId: userStatus?.profile.lastSeenTeamspaceId,
+				feedId,
+				title,
+				content: content === '<p></p>' ? null : content,
+			});
+		}
+	};
+
+	return (
+		<Flex>
+			{id === userStatus?.profile.userId ? (
+				<S.SubTaskPostContainer>
+					<S.PostInput
+						placeholder='제목을 입력해주세요'
+						value={title || ''}
+						onChange={handleTitleChange}
+						maxLength={50}
+					/>
+					<Editor editorRef={editorRef} appendImageFile={appendImageFile} />
+					<Flex justify='flex-end'>
+						<Button
+							label='수정'
+							variant='primary'
+							size='md'
+							onClick={handleSubmitSubTask}
+						/>
+					</Flex>
+				</S.SubTaskPostContainer>
+			) : (
+				subTask && (
+					<Flex direction='column' gap='24'>
+						<FeedAuthor
+							profile={subTask.author.profileImageUrl}
+							initial={subTask.author.username.charAt(0)}
+							title={subTask.author.username}
+							createdAt={getFormattedDate(subTask.updatedAt, 'detail')}
+							tag={subTask.author.tag?.name || ''}
+						/>
+						<Flex direction='column' gap='12'>
+							{subTask.title && <Heading size='xs'>{subTask.title}</Heading>}
+							<Divider size='sm' />
+							<S.DetailWrapper>
+								<div
+									dangerouslySetInnerHTML={{ __html: subTask.content || '' }}
+								/>
+							</S.DetailWrapper>
+						</Flex>
+					</Flex>
+				)
+			)}
+		</Flex>
+	);
+};
+
+export default SubTaskDetail;

--- a/src/components/common/ToastContainer/ToastContainer.styled.ts
+++ b/src/components/common/ToastContainer/ToastContainer.styled.ts
@@ -8,5 +8,5 @@ export const ToastContainerWrapper = styled.div`
 	justify-content: center;
 	align-items: center;
 	gap: ${(props) => props.theme.units.spacing.space12};
-	z-index: ${(props) => props.theme.elevation.zIndex.DIALOG};
+	z-index: 1001;
 `;

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -1,6 +1,8 @@
 export const PROD = import.meta.env.VITE_NODE_ENV === 'production';
 
-export const BASE_URL = `https://api.colla.so/api/v1/`;
+export const BASE_URL = PROD
+	? `${window.location.protocol}//${import.meta.env.VITE_BASE_URL}`
+	: 'http://localhost:3000';
 
 export const END_POINTS = {
 	SIGNIN: 'auth/login',

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -1,8 +1,6 @@
 export const PROD = import.meta.env.VITE_NODE_ENV === 'production';
 
-export const BASE_URL = PROD
-	? `${window.location.protocol}//${import.meta.env.VITE_BASE_URL}`
-	: 'http://localhost:3000';
+export const BASE_URL = `https://api.colla.so/api/v1/`;
 
 export const END_POINTS = {
 	SIGNIN: 'auth/login',
@@ -20,6 +18,10 @@ export const END_POINTS = {
 	FEEDS: (teamspaceId: number) => `teamspaces/${teamspaceId}/feeds`,
 	POST_NORMAL_FEED: (teamspaceId: number) =>
 		`teamspaces/${teamspaceId}/feeds/normal`,
+	GET_COLLECT_SUB_TASK: (teamspaceId: number, feedId: number, userId: number) =>
+		`teamspaces/${teamspaceId}/feeds/collect/${feedId}/responses/users/${userId}`,
+	PATCH_COLLECT_SUB_TASK: (teamspaceId: number, feedId: number) =>
+		`teamspaces/${teamspaceId}/feeds/collect/${feedId}/responses`,
 	POST_COMMENT: (teamspaceId: number, feedId: number) =>
 		`teamspaces/${teamspaceId}/feeds/${feedId}/comments`,
 	COMMENT: (teamspaceId: number, feedId: number, commentId: number) =>

--- a/src/hooks/queries/Feed/Collect/useCollectSubTaskMutation.ts
+++ b/src/hooks/queries/Feed/Collect/useCollectSubTaskMutation.ts
@@ -1,0 +1,41 @@
+import { useErrorBoundary } from 'react-error-boundary';
+import patchCollectSubTask from '@apis/Feed/Collect/patchCollectSubTask';
+import { useMutation } from '@hooks/queries/common/useMutation';
+import { useQueryClient } from '@tanstack/react-query';
+import useToastStore from '@stores/toastStore';
+import { HTTPError } from '@apis/HTTPError';
+import type { CollectSubTaskParams } from '@apis/Feed/Collect/patchCollectSubTask';
+
+const useCollectSubTaskMutation = (
+	teamspaceId: number | undefined,
+	feedId: number
+) => {
+	const { makeToast } = useToastStore();
+	const { showBoundary } = useErrorBoundary();
+	const queryClient = useQueryClient();
+
+	const handleCollectSubTaskSuccess = () => {
+		makeToast('하위 업무 작성 성공', 'Success');
+		queryClient.invalidateQueries({ queryKey: ['feeds', teamspaceId] });
+		queryClient.invalidateQueries({ queryKey: ['subTask', feedId] });
+	};
+
+	const handleCollectSubTaskError = (error: Error) => {
+		if (error instanceof HTTPError) {
+			makeToast('하위 업무 작성을 실패했습니다. 다시 시도해주세요', 'Warning');
+		} else showBoundary(error);
+	};
+
+	const { mutate } = useMutation({
+		onSuccess: handleCollectSubTaskSuccess,
+		onError: handleCollectSubTaskError,
+	});
+
+	const mutateCollectSubTask = async (task: CollectSubTaskParams) => {
+		await mutate(() => patchCollectSubTask(task));
+	};
+
+	return { mutateCollectSubTask };
+};
+
+export default useCollectSubTaskMutation;

--- a/src/hooks/queries/Feed/Collect/useCollectSubTaskMutation.ts
+++ b/src/hooks/queries/Feed/Collect/useCollectSubTaskMutation.ts
@@ -15,14 +15,14 @@ const useCollectSubTaskMutation = (
 	const queryClient = useQueryClient();
 
 	const handleCollectSubTaskSuccess = () => {
-		makeToast('하위 업무 작성 성공', 'Success');
+		makeToast('하위 업무 수정 성공', 'Success');
 		queryClient.invalidateQueries({ queryKey: ['feeds', teamspaceId] });
 		queryClient.invalidateQueries({ queryKey: ['subTask', feedId] });
 	};
 
 	const handleCollectSubTaskError = (error: Error) => {
 		if (error instanceof HTTPError) {
-			makeToast('하위 업무 작성을 실패했습니다. 다시 시도해주세요', 'Warning');
+			makeToast('하위 업무 수정을 실패했습니다. 다시 시도해주세요', 'Warning');
 		} else showBoundary(error);
 	};
 

--- a/src/hooks/queries/Feed/Collect/useCollectSubTaskQuery.ts
+++ b/src/hooks/queries/Feed/Collect/useCollectSubTaskQuery.ts
@@ -1,0 +1,22 @@
+import getCollectSubTask from '@apis/Feed/Collect/getCollectSubTask';
+import { useQuery } from '@tanstack/react-query';
+import type { SubTaskResponse } from '@type/feed';
+
+const useCollectSubTaskQuery = (
+	teamspaceId: number | undefined,
+	feedId: number,
+	userId: number
+) => {
+	const { data: subTask } = useQuery<SubTaskResponse>({
+		queryKey: ['subTask', feedId, userId],
+		queryFn: () => getCollectSubTask(teamspaceId!, feedId, userId),
+
+		gcTime: 24 * 60 * 60 * 1000,
+		staleTime: 24 * 60 * 60 * 1000,
+		enabled: !!teamspaceId,
+	});
+
+	return { subTask };
+};
+
+export default useCollectSubTaskQuery;

--- a/src/types/feed.ts
+++ b/src/types/feed.ts
@@ -41,6 +41,14 @@ interface NormalDetails {
 	content: string | null;
 }
 
+export interface SubTaskResponse {
+	title: string | null;
+	status: 'PENDING' | 'COMPLETED';
+	updatedAt: string;
+	content: string | null;
+	author: Author;
+}
+
 export interface CollectResponse {
 	title: string | null;
 	status: 'PENDING' | 'COMPLETED';


### PR DESCRIPTION
## 📌 관련 이슈

- closed: https://github.com/98OO/colla-frontend/issues/170

## ✨ PR 세부 내용

- 자료 수집 피드 상세 페이지에서 하위 업무 내용 조회 구현
- 자료 수집 피드 상세 페이지에서 하위 업무 내용 작성 및 수정 구현

## 📸 스크린샷(선택)

![image](https://github.com/user-attachments/assets/68e9ae0f-deea-48ee-a5a3-2bea40b2acd2)

![image](https://github.com/user-attachments/assets/0a846b7c-ab60-44da-8f79-71f0569ae91b)


## ✅ 리뷰 요구사항(선택)

- 현재 하위 업무 내용 작성 및 수정 시 기존에 작성된 하위 업무 내용을 불러와 에디터에 반영하는 부분은 추후 구현할 예정입니다.
