### PR TITLE
재발급된 access token이 정상적으로 반영될 수 있도록 수정

### DIFF
--- a/src/apis/axiosInterceptors.ts
+++ b/src/apis/axiosInterceptors.ts
@@ -24,7 +24,7 @@ export const setAuthorizedRequest = (config: InternalAxiosRequestConfig) => {
 	const accessToken = localStorage.getItem(ACCESS_TOKEN);
 
 	if (!accessToken) {
-		window.location.href = PATH.SIGNIN;
+		window.location.href = PATH.ROOT;
 		throw new Error('인증 토큰이 없습니다. 다시 로그인해주세요.');
 	}
 

--- a/src/apis/user/getNewToken.ts
+++ b/src/apis/user/getNewToken.ts
@@ -1,10 +1,13 @@
 import { axiosInstance } from '@apis/axiosInstance';
 import { END_POINTS } from '@constants/api';
-import type { AccessToken } from '@type/user';
+import type { NewToken } from '@type/user';
 
 export const getNewToken = async () => {
-	const { data } = await axiosInstance.get<AccessToken>(END_POINTS.NEWTOKEN, {
+	const { data } = await axiosInstance.get<NewToken>(END_POINTS.NEWTOKEN, {
 		authRequired: false,
 	});
-	return data;
+
+	const { content } = data;
+
+	return content;
 };

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,5 +1,11 @@
-export interface AccessToken {
-	accessToken: string;
+export interface NewToken {
+	code: number;
+	content: {
+		accessToken: string;
+		hasTeam: boolean;
+		userId: number;
+	};
+	message: string;
 }
 
 export interface UserProfile {


### PR DESCRIPTION
## 📌 관련 이슈

- https://github.com/98OO/colla-frontend/issues/183

## ✨ PR 세부 내용

- `authRequired` 요청 시도 중 `accessToken` 만료 (40183) 시 `refreshToken` 을 사용해 재발급 시도
재발급된 `accessToken` 으로 실패한 요청을 재시도했으나 비정상적인 토큰 (40184) 에러 발생

    확인을 위해 `accessToken` 을 확인한 결과 사용 시 `undefined`임을 확인
    백엔드의 `accessToken` 재발급 개발 이전에 임의로 작성했기에 실제로 전달받는 형식과 달라서 발생한 문제임을 확인
    재발급된 `accessToken`이 정상적으로 반영될 수 있도록 API 수정

- `accessToken`과 `refreshToken` 모두 만료된 경우 랜딩페이지로 이동하도록 수정
