### PR TITLE
피드 데이터 dompurify 적용 유틸 함수의 타입 이슈 해결

### DIFF
--- a/src/utils/getSanitizedFeeds.ts
+++ b/src/utils/getSanitizedFeeds.ts
@@ -3,10 +3,12 @@ import type { FeedData } from '@type/feed';
 
 export const getSanitizedFeeds = (dirtyFeeds: FeedData[]) => {
 	const sanitizedFeeds = dirtyFeeds.map((feed) => {
-		const sanitizedContent = DOMPurify.sanitize(feed.details.content || '');
+		const { feedType, details } = feed;
 
-		switch (feed.feedType) {
-			case 'NORMAL': {
+		if (feedType === 'NORMAL' || feedType === 'COLLECT') {
+			const sanitizedContent = DOMPurify.sanitize(details.content || '');
+
+			if (feed.feedType === 'NORMAL') {
 				return {
 					...feed,
 					details: {
@@ -15,8 +17,10 @@ export const getSanitizedFeeds = (dirtyFeeds: FeedData[]) => {
 					},
 				};
 			}
-			case 'COLLECT': {
+
+			if (feed.feedType === 'COLLECT') {
 				const { dueAt, isClosed, responses } = feed.details;
+
 				return {
 					...feed,
 					details: {
@@ -28,9 +32,9 @@ export const getSanitizedFeeds = (dirtyFeeds: FeedData[]) => {
 					},
 				};
 			}
-			default:
-				return feed;
 		}
+
+		return feed;
 	});
 
 	return sanitizedFeeds;


### PR DESCRIPTION
## 📌 관련 이슈

- https://github.com/98OO/colla-frontend/issues/175

## ✨ PR 세부 내용

- 에디터로 작성한 내용인 innerHtml을 가지는 일반 피드와 자료 수집 피드만 dompurify를 적용하도록 변경
