### PR TITLE
자료수집 및 일정조율 피드 작성 시 기본 마감 일자를 3일 뒤로 변경

### DIFF
--- a/src/components/Post/Calendar/Calendar.styled.ts
+++ b/src/components/Post/Calendar/Calendar.styled.ts
@@ -51,6 +51,7 @@ export const Date = styled.div<{ isSelected: boolean }>`
 	align-items: center;
 	width: 40px;
 	height: 40px;
+	cursor: pointer;
 
 	${({ isSelected }) =>
 		isSelected &&

--- a/src/hooks/post/useCalendar.ts
+++ b/src/hooks/post/useCalendar.ts
@@ -135,7 +135,18 @@ const useCalendar = () => {
 
 	const getInitialDueAt = (dueAt: string) => {
 		if (dueAt === '') {
-			return [getToday(true)];
+			const threeDaysLater = new Date();
+			threeDaysLater.setDate(threeDaysLater.getDate() + 3);
+
+			return [
+				{
+					year: threeDaysLater.getFullYear(),
+					month: threeDaysLater.getMonth() + 1,
+					day: threeDaysLater.getDate(),
+					hour: threeDaysLater.getHours(),
+					minute: threeDaysLater.getMinutes(),
+				},
+			];
 		}
 
 		return [getDayObject(dueAt, true)];


### PR DESCRIPTION
## 📌 관련 이슈

-closed: https://github.com/98OO/colla-frontend/issues/197

## ✨ PR 세부 내용
현재 기본 마감일이 오늘로 되어 있습니다. 이를 3일 뒤로 변경합니다.
- [x] useCalendar의 getInitialDueAt 에서 3일 뒤의 날짜를 반환하도록 변경

## 📸 스크린샷
<img width="1425" alt="스크린샷 2025-03-25 오후 10 29 46" src="https://github.com/user-attachments/assets/acaad3be-0990-4063-a82d-6e59a0343978" />
