### PR TITLE
팀스페이스의 읽지 않은 채팅 개수 조회 방식 변경

### DIFF
--- a/src/apis/teamspace/getUnreadMessageCount.ts
+++ b/src/apis/teamspace/getUnreadMessageCount.ts
@@ -1,0 +1,15 @@
+import { axiosInstance } from '@apis/axiosInstance';
+import { END_POINTS } from '@constants/api';
+import type { UnreadMessageCountResponse } from '@type/team';
+
+const getUnreadMessageCount = async (
+	teamspaceId: number
+): Promise<UnreadMessageCountResponse> => {
+	const response = await axiosInstance.get(
+		END_POINTS.GET_UNREAD_MESSAGE_COUNT(teamspaceId)
+	);
+
+	return response.data.content;
+};
+
+export default getUnreadMessageCount;

--- a/src/components/Chat/MyMessageBox/MyMessageBox.styled.ts
+++ b/src/components/Chat/MyMessageBox/MyMessageBox.styled.ts
@@ -40,7 +40,6 @@ export const TimeWrapper = styled.div`
 	flex-direction: column;
 	justify-content: flex-end;
 	flex-shrink: 0;
-	width: 54px;
 	min-width: 54px;
 	flex-direction: column;
 	align-items: flex-end;

--- a/src/components/Chat/OtherMessageBox/OtherMessageBox.styled.ts
+++ b/src/components/Chat/OtherMessageBox/OtherMessageBox.styled.ts
@@ -49,7 +49,6 @@ export const TimeWrapper = styled.div`
 	flex-direction: column;
 	justify-content: flex-end;
 	flex-shrink: 0;
-	width: 54px;
 	min-width: 54px;
 	flex-direction: column;
 	align-items: flex-start;

--- a/src/components/Chat/OtherMessageBox/OtherMessageBox.tsx
+++ b/src/components/Chat/OtherMessageBox/OtherMessageBox.tsx
@@ -33,49 +33,51 @@ const OtherMessageBox = (props: OtherMessageBoxProps) => {
 						{name}
 					</Text>
 				)}
-				<S.OtherMessageBoxWrapper state={state} type={type}>
-					{type === 'TEXT' && (
-						<Text size='lg' weight='regular' color='secondary'>
-							{content}
-						</Text>
-					)}
-					{type === 'IMAGE' && (
-						<S.ImageWrapper>
-							{file?.map((img) => (
-								<a
-									key={img.id}
-									href={img.url}
-									target='_blank'
-									rel='noopener noreferrer'>
-									<img src={img.url} alt={img.filename} />
-								</a>
-							))}
-						</S.ImageWrapper>
-					)}
-					{type === 'FILE' && (
-						<Flex gap='10'>
-							{file?.map((files) => (
-								<ChatAttachments
-									key={files.id}
-									attachment={{
-										id: files.id,
-										name: files.filename,
-										fileUrl: files.url,
-										size: files.size,
-									}}
-								/>
-							))}
-						</Flex>
-					)}
-				</S.OtherMessageBoxWrapper>
+				<Flex gap='8'>
+					<S.OtherMessageBoxWrapper state={state} type={type}>
+						{type === 'TEXT' && (
+							<Text size='lg' weight='regular' color='secondary'>
+								{content}
+							</Text>
+						)}
+						{type === 'IMAGE' && (
+							<S.ImageWrapper>
+								{file?.map((img) => (
+									<a
+										key={img.id}
+										href={img.url}
+										target='_blank'
+										rel='noopener noreferrer'>
+										<img src={img.url} alt={img.filename} />
+									</a>
+								))}
+							</S.ImageWrapper>
+						)}
+						{type === 'FILE' && (
+							<Flex gap='10'>
+								{file?.map((files) => (
+									<ChatAttachments
+										key={files.id}
+										attachment={{
+											id: files.id,
+											name: files.filename,
+											fileUrl: files.url,
+											size: files.size,
+										}}
+									/>
+								))}
+							</Flex>
+						)}
+					</S.OtherMessageBoxWrapper>
+					<S.TimeWrapper>
+						{date && (
+							<Text size='sm' weight='regular' color='subtle'>
+								{date}
+							</Text>
+						)}
+					</S.TimeWrapper>
+				</Flex>
 			</Flex>
-			<S.TimeWrapper>
-				{date && (
-					<Text size='sm' weight='regular' color='subtle'>
-						{date}
-					</Text>
-				)}
-			</S.TimeWrapper>
 			<S.OtherMessageBoxSpacer />
 		</S.OtherMessageBoxContainer>
 	);

--- a/src/components/common/SideNavigationBar/SNBFull/SNBFull.tsx
+++ b/src/components/common/SideNavigationBar/SNBFull/SNBFull.tsx
@@ -8,6 +8,7 @@ import FeedMenu from '@components/common/SideNavigationBar/FeedMenu/FeedMenu';
 import MenuItem from '@components/common/SideNavigationBar/MenuItem/MenuItem';
 import Text from '@components/common/Text/Text';
 import useMenu from '@hooks/common/useMenu';
+import useUnreadMessageCountQuery from '@hooks/queries/teamspace/useUnreadMessageCountQuery';
 import useUserStatusQuery from '@hooks/queries/useUserStatusQuery';
 import useSocketStore from '@stores/socketStore';
 import { PATH } from '@constants/path';
@@ -23,10 +24,9 @@ const SNBFull = () => {
 	const teamRole = teamspaces?.find(
 		(teamspace) => teamspace.teamspaceId === lastSeenTeamspaceId
 	)?.teamspaceRole;
-	const unreadMessageCount = teamspaces?.find(
-		(teamspace) => teamspace.teamspaceId === lastSeenTeamspaceId
-	)?.unreadMessageCount;
 
+	const { unreadMessageCount } =
+		useUnreadMessageCountQuery(lastSeenTeamspaceId);
 	const { chatMessageCount } = useSocketStore();
 	const baseRef = useRef<HTMLDivElement>(null);
 	const { toggleMenu: handleFeedMenu, showMenu: showFeedMenu } = useMenu();

--- a/src/components/common/SideNavigationBar/SNBIcon/SNBIcon.tsx
+++ b/src/components/common/SideNavigationBar/SNBIcon/SNBIcon.tsx
@@ -6,6 +6,7 @@ import Flex from '@components/common/Flex/Flex';
 import FeedMenu from '@components/common/SideNavigationBar/FeedMenu/FeedMenu';
 import MenuItem from '@components/common/SideNavigationBar/MenuItem/MenuItem';
 import useMenu from '@hooks/common/useMenu';
+import useUnreadMessageCountQuery from '@hooks/queries/teamspace/useUnreadMessageCountQuery';
 import useUserStatusQuery from '@hooks/queries/useUserStatusQuery';
 import useSocketStore from '@stores/socketStore';
 import { PATH } from '@constants/path';
@@ -21,9 +22,9 @@ const SNBIcon = () => {
 	const teamRole = teamspaces?.find(
 		(teamspace) => teamspace.teamspaceId === lastSeenTeamspaceId
 	)?.teamspaceRole;
-	const unreadMessageCount = teamspaces?.find(
-		(teamspace) => teamspace.teamspaceId === lastSeenTeamspaceId
-	)?.unreadMessageCount;
+
+	const { unreadMessageCount } =
+		useUnreadMessageCountQuery(lastSeenTeamspaceId);
 
 	const { chatMessageCount } = useSocketStore();
 	const baseRef = useRef<HTMLDivElement>(null);

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -52,6 +52,8 @@ export const END_POINTS = {
 		`/topic/teamspaces/${teamspaceId}/receive-message`,
 	SEND_CHAT_CHANNEL_LIST: (teamspaceId: number, userId: number) =>
 		`/app/teamspaces/${teamspaceId}/users/${userId}/chat-channels/status`,
+	GET_UNREAD_MESSAGE_COUNT: (teamspaceId: number) =>
+		`/teamspaces/${teamspaceId}/unread-count`,
 } as const;
 
 export const AUTH_ERROR_CODE = {

--- a/src/hooks/queries/teamspace/useRecordTeamSpace.ts
+++ b/src/hooks/queries/teamspace/useRecordTeamSpace.ts
@@ -10,6 +10,7 @@ const useRecordTeamSpace = () => {
 		queryClient.removeQueries({ queryKey: ['teamSetting'] });
 		queryClient.removeQueries({ queryKey: ['teamSpaceUsers'] });
 		queryClient.removeQueries({ queryKey: ['chatChannel'] });
+		queryClient.removeQueries({ queryKey: ['unreadMessage'] });
 	};
 
 	const { mutate } = useMutation({

--- a/src/hooks/queries/teamspace/useUnreadMessageCountQuery.ts
+++ b/src/hooks/queries/teamspace/useUnreadMessageCountQuery.ts
@@ -1,0 +1,17 @@
+import getUnreadMessageCount from '@apis/teamspace/getUnreadMessageCount';
+import { useQuery } from '@tanstack/react-query';
+import type { UnreadMessageCountResponse } from '@type/team';
+
+const useUnreadMessageCountQuery = (teamspaceId?: number) => {
+	const { data } = useQuery<UnreadMessageCountResponse>({
+		queryKey: ['unreadMessage'],
+		queryFn: () => getUnreadMessageCount(teamspaceId!),
+		gcTime: 60 * 60 * 60 * 1000,
+		staleTime: 60 * 60 * 60 * 1000,
+		enabled: !!teamspaceId,
+	});
+
+	return { unreadMessageCount: data?.unreadMessageCount };
+};
+
+export default useUnreadMessageCountQuery;

--- a/src/types/team.ts
+++ b/src/types/team.ts
@@ -38,3 +38,7 @@ export interface TeamSettingResult {
 		tagId: number | null;
 	}[];
 }
+
+export interface UnreadMessageCountResponse {
+	unreadMessageCount: number;
+}


### PR DESCRIPTION
## 📌 관련 이슈

- closed: https://github.com/98OO/colla-frontend/issues/199

## ✨ PR 세부 내용

- 기존에는 사용자 상태 정보에서 읽지 않은 채팅 개수를 조회했으나, 팀스페이스의 읽지 않은 채팅 개수를 별도의 API 호출을 통해 조회하도록 방식 변경


