### PR TITLE
일정 조율 퍼널 개선 및 브라우저 히스토리 연동

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -8,5 +8,6 @@
 	"bracketSpacing": true,
 	"bracketSameLine": true,
 	"arrowParens": "always",
-	"quoteProps": "as-needed"
+	"quoteProps": "as-needed",
+	"printWidth": 100
 }

--- a/src/components/Post/SchedulingPost/SchedulingPost.tsx
+++ b/src/components/Post/SchedulingPost/SchedulingPost.tsx
@@ -1,21 +1,22 @@
 import { useState } from 'react';
 import SelectDateStep from '@components/Post/SchedulingPost/Step/SelectDateStep';
 import SetTimeStep from '@components/Post/SchedulingPost/Step/SetTimeStep';
+import useHistoryFunnel from '@hooks/common/funnel/useHistoryFunnel';
 import useSchedulingFeedMutation from '@hooks/queries/post/useSchedulingFeedMutation';
 import useUserStatusQuery from '@hooks/queries/useUserStatusQuery';
 import { INITIAL_SCHEDULING_FORM } from '@constants/post';
 import type { SchedulingFeedForm } from '@type/feed';
-import type { SchedulingPostStep } from '@type/post';
 import * as S from './SchedulingPost.styled';
 
+const STEPS = ['selectDate', 'setTime'] as const;
+
 const SchedulingPost = () => {
+	const { Funnel, step, goNext, goPrev } = useHistoryFunnel(STEPS);
+
 	const { userStatus } = useUserStatusQuery();
 	const teamspaceId = userStatus?.profile.lastSeenTeamspaceId;
 
-	const [step, setStep] = useState<SchedulingPostStep>('selectDate');
-	const [formData, setFormData] = useState<SchedulingFeedForm>(
-		INITIAL_SCHEDULING_FORM
-	);
+	const [formData, setFormData] = useState<SchedulingFeedForm>(INITIAL_SCHEDULING_FORM);
 
 	const { mutateSchedulingFeed } = useSchedulingFeedMutation();
 
@@ -54,21 +55,23 @@ const SchedulingPost = () => {
 
 	return (
 		<S.SchedulingPostContainer>
-			{step === 'selectDate' && (
-				<SelectDateStep
-					onNext={() => setStep('setTime')}
-					targetDates={formData.details.targetDates}
-					handleTargetDates={handleTargetDates}
-				/>
-			)}
-			{step === 'setTime' && (
-				<SetTimeStep
-					onPrev={() => setStep('selectDate')}
-					dueAt={formData.details.dueAt}
-					handleDetail={handleDetail}
-					onSubmit={handleSubmit}
-				/>
-			)}
+			<Funnel step={step}>
+				<Funnel.Step name='selectDate'>
+					<SelectDateStep
+						onNext={goNext}
+						targetDates={formData.details.targetDates}
+						handleTargetDates={handleTargetDates}
+					/>
+				</Funnel.Step>
+				<Funnel.Step name='setTime'>
+					<SetTimeStep
+						onPrev={goPrev}
+						dueAt={formData.details.dueAt}
+						handleDetail={handleDetail}
+						onSubmit={handleSubmit}
+					/>
+				</Funnel.Step>
+			</Funnel>
 		</S.SchedulingPostContainer>
 	);
 };

--- a/src/hooks/common/funnel/useFunnel.tsx
+++ b/src/hooks/common/funnel/useFunnel.tsx
@@ -1,0 +1,54 @@
+import { createContext, useCallback, useContext, useMemo, useState } from 'react';
+
+const createFunnel = <T extends string>() => {
+	const StepContext = createContext<T | null>(null);
+
+	const Funnel = ({ step, children }: { step: T; children: React.ReactNode }) => {
+		return <StepContext.Provider value={step}>{children}</StepContext.Provider>;
+	};
+
+	Funnel.Step = function Step({ name, children }: { name: T; children: React.ReactNode }) {
+		const curStep = useContext(StepContext);
+
+		if (curStep === null) {
+			throw new Error('<Funnel.Step>은 <Funnel> 내부에서 사용해주세요.');
+		}
+
+		return curStep === name ? children : null;
+	};
+
+	return Funnel;
+};
+
+const useFunnel = <T extends string>(steps: readonly [T, ...T[]]) => {
+	const [step, setStep] = useState<T>(steps[0]);
+
+	const stepIndexMap = useMemo(() => {
+		const map = new Map<T, number>();
+		steps.forEach((s, i) => map.set(s, i));
+
+		return map;
+	}, [steps]);
+
+	const prev = useCallback(() => {
+		setStep((curStep) => {
+			const curIndex = stepIndexMap.get(curStep)!;
+
+			return steps[curIndex - 1];
+		});
+	}, [steps, stepIndexMap]);
+
+	const next = useCallback(() => {
+		setStep((curStep) => {
+			const curIndex = stepIndexMap.get(curStep)!;
+
+			return steps[curIndex + 1];
+		});
+	}, [steps, stepIndexMap]);
+
+	const Funnel = useMemo(() => createFunnel<T>(), []);
+
+	return { Funnel, step, setStep, prev, next };
+};
+
+export default useFunnel;

--- a/src/hooks/common/funnel/useHistoryFunnel.tsx
+++ b/src/hooks/common/funnel/useHistoryFunnel.tsx
@@ -1,0 +1,24 @@
+import { useCallback } from 'react';
+import useFunnel from '@hooks/common/funnel/useFunnel';
+import useHistory from '@hooks/common/useHistory';
+
+const useHistoryFunnel = <T extends string>(steps: readonly [T, ...T[]]) => {
+	const { Funnel, step, setStep, next } = useFunnel<T>(steps);
+	const { push, back } = useHistory<T>(step, setStep);
+
+	const goNext = useCallback(() => {
+		const nextStep = steps[steps.indexOf(step) + 1];
+		if (!nextStep) return;
+
+		next();
+		push(nextStep);
+	}, [step, steps, next, push]);
+
+	const goPrev = useCallback(() => {
+		back();
+	}, [back]);
+
+	return { Funnel, step, goNext, goPrev };
+};
+
+export default useHistoryFunnel;

--- a/src/hooks/common/useHistory.ts
+++ b/src/hooks/common/useHistory.ts
@@ -1,0 +1,37 @@
+import { useEffect, useCallback } from 'react';
+import useUpdatableRef from '@hooks/common/useUpdatableRef';
+
+const useHistory = <T>(initialEntryData: T, onPopState: (entryData: T) => void) => {
+	const onPopStateRef = useUpdatableRef(onPopState);
+
+	useEffect(() => {
+		window.history.replaceState({ entryData: initialEntryData }, '', window.location.href);
+	}, []);
+
+	useEffect(() => {
+		const handlePopState = (event: PopStateEvent) => {
+			if (event.state?.entryData != null) {
+				onPopStateRef.current(event.state.entryData);
+			}
+		};
+
+		window.addEventListener('popstate', handlePopState);
+		return () => window.removeEventListener('popstate', handlePopState);
+	}, []);
+
+	const push = useCallback((nextEntryData: T) => {
+		window.history.pushState({ entryData: nextEntryData }, '', window.location.href);
+	}, []);
+
+	const replace = useCallback((nextEntryData: T) => {
+		window.history.replaceState({ entryData: nextEntryData }, '');
+	}, []);
+
+	const back = useCallback(() => {
+		window.history.back();
+	}, []);
+
+	return { push, replace, back };
+};
+
+export default useHistory;

--- a/src/hooks/common/useUpdatableRef.ts
+++ b/src/hooks/common/useUpdatableRef.ts
@@ -1,0 +1,9 @@
+import { useRef } from 'react';
+
+const useUpdatableRef = <T>(value: T) => {
+	const ref = useRef(value);
+	ref.current = value;
+	return ref;
+};
+
+export default useUpdatableRef;


### PR DESCRIPTION
## 📌 관련 이슈

- closed: https://github.com/98OO/colla-frontend/issues/201

## ✨ PR 세부 내용
- 퍼널 로직을 브라우저 히스토리와 연동하고, 이를 위한 공통 훅들을 추가했습니다
  - `useFunnel` : context 기반으로 현재 스텝을 관리하는 퍼널 훅
  - `useHistory` : 브라우저 History API를 추상화한 훅
  - `useHistoryFunnel` : `useFunnel`과 `useHistory`를 결합한 훅
  - `useUpdatableRef` : 최신 값 동기화를 위한 훅
- prettier에 `printWidth` 옵션을 추가했습니다

## ✅ 리뷰 요구사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 일정 게시물 작성의 단계별 네비게이션에 브라우저 뒤로/앞으로 이동 지원이 추가되었습니다.

* **Refactor**
  * 일정 게시물의 단계 관리가 중앙화되어 이전보다 일관된 흐름과 더 간결한 전환이 적용되었습니다.

* **Chores**
  * 코드 포맷팅 설정(print width 등)이 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->