### PR TITLE
자료저장소 UI 및 기능 리팩토링

### DIFF
--- a/src/apis/common/putFileUpload.ts
+++ b/src/apis/common/putFileUpload.ts
@@ -14,7 +14,7 @@ const putFileUpload = async ({
 	const response = await axiosInstance.put(presignedURL, file, {
 		headers: {
 			'Content-Type': contentType,
-			'Content-Disposition': `attachment; filename="${file.name}"; filename*=UTF-8''${encodeURIComponent(file.name)}`,
+			'Content-Disposition': `attachment; filename*=UTF-8''${encodeURIComponent(file.name)}`,
 		},
 		authRequired: false,
 	});

--- a/src/apis/common/putFileUpload.ts
+++ b/src/apis/common/putFileUpload.ts
@@ -14,6 +14,7 @@ const putFileUpload = async ({
 	const response = await axiosInstance.put(presignedURL, file, {
 		headers: {
 			'Content-Type': contentType,
+			'Content-Disposition': `attachment; filename="${file.name}"; filename*=UTF-8''${encodeURIComponent(file.name)}`,
 		},
 		authRequired: false,
 	});

--- a/src/components/Document/DocumentItem/DocumentItem.styled.ts
+++ b/src/components/Document/DocumentItem/DocumentItem.styled.ts
@@ -3,20 +3,20 @@ import theme from '@styles/theme';
 
 export const DocumentItemContainer = styled.div`
 	display: flex;
-	height: 55px;
+	min-height: 36px;
 `;
 
 export const DocumentNameContainer = styled.div`
 	display: flex;
 	align-items: center;
 	width: 45%;
-	gap: ${theme.units.spacing.space16};
+	gap: ${theme.units.spacing.space12};
 	padding: 0 ${theme.units.spacing.space6};
 `;
 
 export const DocumentCheckbox = styled.input.attrs({ type: 'checkbox' })`
-	width: 20px;
-	height: 20px;
+	width: 18px;
+	height: 18px;
 	cursor: pointer;
 	appearance: none;
 	border: 1.5px solid ${theme.color.border.iSecondary};
@@ -29,7 +29,7 @@ export const DocumentCheckbox = styled.input.attrs({ type: 'checkbox' })`
 
 	&:checked::after {
 		content: '✓';
-		font-size: ${theme.typography.fontSize.body.lg};
+		font-size: ${theme.typography.fontSize.body.md};
 		color: white;
 		display: flex;
 		justify-content: center;

--- a/src/components/Document/DocumentItem/DocumentItem.styled.ts
+++ b/src/components/Document/DocumentItem/DocumentItem.styled.ts
@@ -38,10 +38,16 @@ export const DocumentCheckbox = styled.input.attrs({ type: 'checkbox' })`
 `;
 
 export const DocumentNameWrapper = styled.div`
-	width: 75%;
+	flex: 1;
+	min-width: 0;
 	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
+
+	& > p {
+		overflow: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+		line-height: 1.5;
+	}
 `;
 
 export const DocumentItemWrapper = styled.div<{ width: string }>`

--- a/src/components/Document/DocumentItem/DocumentItem.tsx
+++ b/src/components/Document/DocumentItem/DocumentItem.tsx
@@ -1,4 +1,3 @@
-import Icon from '@components/common/Icon/Icon';
 import Text from '@components/common/Text/Text';
 import { getFormattedDate } from '@utils/getFormattedDate';
 import { getUnitFormattedSize } from '@utils/getUnitFormattedSize';
@@ -14,10 +13,6 @@ interface DocumentItemProps {
 const DocumentItem = (props: DocumentItemProps) => {
 	const { attachment, selectedDocument, handleDocumentClick } = props;
 
-	const removeFileExtension = (fileName: string) => {
-		return fileName.substring(0, fileName.lastIndexOf('.'));
-	};
-
 	return (
 		<S.DocumentItemContainer>
 			<S.DocumentNameContainer>
@@ -25,10 +20,9 @@ const DocumentItem = (props: DocumentItemProps) => {
 					checked={selectedDocument.includes(attachment.fileUrl)}
 					onChange={() => handleDocumentClick(attachment.fileUrl)}
 				/>
-				<Icon name='PDF' />
 				<S.DocumentNameWrapper>
 					<Text size='lg' weight='regular'>
-						{removeFileExtension(attachment.name)}
+						{attachment.name}
 					</Text>
 				</S.DocumentNameWrapper>
 			</S.DocumentNameContainer>

--- a/src/components/Document/DocumentItem/DocumentItem.tsx
+++ b/src/components/Document/DocumentItem/DocumentItem.tsx
@@ -6,7 +6,7 @@ import * as S from './DocumentItem.styled';
 
 interface DocumentItemProps {
 	attachment: Document;
-	selectedDocument: string[];
+	selectedDocument: Set<string>;
 	handleDocumentClick: (fileUrl: string) => void;
 }
 
@@ -17,7 +17,7 @@ const DocumentItem = (props: DocumentItemProps) => {
 		<S.DocumentItemContainer>
 			<S.DocumentNameContainer>
 				<S.DocumentCheckbox
-					checked={selectedDocument.includes(attachment.fileUrl)}
+					checked={selectedDocument.has(attachment.fileUrl)}
 					onChange={() => handleDocumentClick(attachment.fileUrl)}
 				/>
 				<S.DocumentNameWrapper>

--- a/src/components/common/Button/Button.styled.ts
+++ b/src/components/common/Button/Button.styled.ts
@@ -98,6 +98,7 @@ export const ButtonWrapper = styled.button.withConfig({
 	padding: ${(props) =>
 		`${props.theme.units.spacing.space8} ${btnPaddingSizeMap[props.size]}`};
 	gap: ${(props) => props.theme.units.spacing.space4};
+	cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
 
 	svg {
 		width: ${(props) => btnIconSizeMap[props.size]};
@@ -117,8 +118,4 @@ export const ButtonWrapper = styled.button.withConfig({
 			${variantStyle[variant]}
 		`;
 	}};
-
-	&:hover {
-		cursor: pointer;
-	}
 `;

--- a/src/components/common/IconButton/IconButton.styled.ts
+++ b/src/components/common/IconButton/IconButton.styled.ts
@@ -10,11 +10,10 @@ export const IconButtonWrapper = styled.button<{ disabled: boolean }>`
 	aspect-ratio: 1/1;
 	padding: ${theme.units.spacing.space4};
 	border-radius: ${theme.units.radius.radius6};
-	cursor: pointer;
+	cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
 	opacity: ${({ disabled }) => (disabled ? 0.2 : 1)};
 
-	&:hover {
-		background-color: ${({ disabled }) =>
-			disabled ? theme.color.icon.disabled : theme.color.bg.iSecondaryHover};
+	&:not(:disabled):hover {
+		background-color: ${theme.color.bg.iSecondaryHover};
 	}
 `;

--- a/src/hooks/document/useDocumentDownload.ts
+++ b/src/hooks/document/useDocumentDownload.ts
@@ -1,0 +1,32 @@
+interface UseDocumentDownloadParams {
+	selectedDocument: Set<string>;
+	downloadIntervalMs: number;
+	onAfterDownload: () => void;
+}
+
+const useDocumentDownload = ({
+	selectedDocument,
+	downloadIntervalMs,
+	onAfterDownload,
+}: UseDocumentDownloadParams) => {
+	const handleDownloadClick = () => {
+		Array.from(selectedDocument).forEach((fileUrl, index) => {
+			window.setTimeout(() => {
+				const link = document.createElement('a');
+
+				link.href = fileUrl;
+				link.download = '';
+
+				document.body.appendChild(link);
+				link.click();
+				document.body.removeChild(link);
+			}, index * downloadIntervalMs);
+		});
+
+		onAfterDownload();
+	};
+
+	return { handleDownloadClick };
+};
+
+export default useDocumentDownload;

--- a/src/hooks/document/useDocumentPagination.ts
+++ b/src/hooks/document/useDocumentPagination.ts
@@ -1,0 +1,68 @@
+import { useMemo, useState } from 'react';
+import {
+	getDocumentPageNumbers,
+	getLastPageNumber,
+	getVisibleDocuments,
+} from '@utils/document/documentPagination';
+import type { Document } from '@type/document';
+
+type PageDirection = 'prev' | 'next';
+
+interface UseDocumentPaginationParams {
+	attachments: Document[];
+	itemsPerPage: number;
+	pageGroupSize: number;
+}
+
+const useDocumentPagination = ({
+	attachments,
+	itemsPerPage,
+	pageGroupSize,
+}: UseDocumentPaginationParams) => {
+	const [selectedNumber, setSelectedNumber] = useState(1);
+	const lastPageNumber = getLastPageNumber(attachments.length, itemsPerPage);
+	const visibleAttachments = useMemo(
+		() => getVisibleDocuments(attachments, selectedNumber, itemsPerPage),
+		[attachments, itemsPerPage, selectedNumber]
+	);
+	const pageNumbers = useMemo(
+		() => getDocumentPageNumbers(selectedNumber, lastPageNumber, pageGroupSize),
+		[lastPageNumber, pageGroupSize, selectedNumber]
+	);
+
+	const handleNumberClick = (number: number) => {
+		if (number !== selectedNumber) setSelectedNumber(number);
+	};
+
+	const handlePageClick = (direction: PageDirection) => {
+		setSelectedNumber((prev) => (direction === 'prev' ? prev - 1 : prev + 1));
+	};
+
+	const handlePageGroupClick = (direction: PageDirection) => {
+		if (attachments.length === 0) return;
+
+		setSelectedNumber((prev) =>
+			direction === 'prev'
+				? Math.max(
+						(Math.floor((prev - 1) / pageGroupSize) - 1) * pageGroupSize + 1,
+						1
+					)
+				: Math.min(
+						Math.ceil(prev / pageGroupSize) * pageGroupSize + 1,
+						lastPageNumber
+					)
+		);
+	};
+
+	return {
+		selectedNumber,
+		visibleAttachments,
+		lastPageNumber,
+		pageNumbers,
+		handleNumberClick,
+		handlePageClick,
+		handlePageGroupClick,
+	};
+};
+
+export default useDocumentPagination;

--- a/src/hooks/document/useDocumentSelection.ts
+++ b/src/hooks/document/useDocumentSelection.ts
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+import type { Document } from '@type/document';
+
+interface UseDocumentSelectionParams {
+	visibleAttachments: Document[];
+}
+
+const useDocumentSelection = ({
+	visibleAttachments,
+}: UseDocumentSelectionParams) => {
+	const [selectedDocument, setSelectedDocument] = useState<Set<string>>(
+		new Set()
+	);
+	const selectedVisibleCount = visibleAttachments.filter((attachment) =>
+		selectedDocument.has(attachment.fileUrl)
+	).length;
+	const isAllVisibleSelected =
+		visibleAttachments.length > 0 &&
+		selectedVisibleCount === visibleAttachments.length;
+
+	const handleDocumentClick = (fileUrl: string) => {
+		setSelectedDocument((prevSelected) => {
+			const nextSelected = new Set(prevSelected);
+
+			if (nextSelected.has(fileUrl)) nextSelected.delete(fileUrl);
+			else nextSelected.add(fileUrl);
+
+			return nextSelected;
+		});
+	};
+
+	const handleSelectAllClick = () => {
+		setSelectedDocument((prevSelected) => {
+			const nextSelected = new Set(prevSelected);
+
+			if (isAllVisibleSelected) {
+				visibleAttachments.forEach((attachment) =>
+					nextSelected.delete(attachment.fileUrl)
+				);
+			} else {
+				visibleAttachments.forEach((attachment) =>
+					nextSelected.add(attachment.fileUrl)
+				);
+			}
+
+			return nextSelected;
+		});
+	};
+
+	const clearSelectedDocument = () => {
+		setSelectedDocument(new Set());
+	};
+
+	return {
+		selectedDocument,
+		isAllVisibleSelected,
+		handleDocumentClick,
+		handleSelectAllClick,
+		clearSelectedDocument,
+	};
+};
+
+export default useDocumentSelection;

--- a/src/hooks/queries/document/useDocumentQuery.ts
+++ b/src/hooks/queries/document/useDocumentQuery.ts
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { storageResponse } from '@type/document';
 
 const useDocumentQuery = (teamspaceId?: number) => {
-	const { data: teamDocument } = useQuery<storageResponse>({
+	const { data: teamDocument, isPending } = useQuery<storageResponse>({
 		queryKey: ['teamDocument', teamspaceId],
 		queryFn: () => getDocument(teamspaceId!),
 
@@ -12,7 +12,7 @@ const useDocumentQuery = (teamspaceId?: number) => {
 		refetchOnWindowFocus: false,
 	});
 
-	return { teamDocument };
+	return { teamDocument, isPending };
 };
 
 export default useDocumentQuery;

--- a/src/hooks/queries/document/useDocumentQuery.ts
+++ b/src/hooks/queries/document/useDocumentQuery.ts
@@ -7,9 +7,9 @@ const useDocumentQuery = (teamspaceId?: number) => {
 		queryKey: ['teamDocument', teamspaceId],
 		queryFn: () => getDocument(teamspaceId!),
 
-		gcTime: 60 * 60 * 60 * 1000,
-		staleTime: 60 * 60 * 60 * 1000,
 		enabled: !!teamspaceId,
+		refetchOnMount: 'always',
+		refetchOnWindowFocus: false,
 	});
 
 	return { teamDocument };

--- a/src/pages/DocumentPage/DocumentPage.styled.ts
+++ b/src/pages/DocumentPage/DocumentPage.styled.ts
@@ -45,8 +45,8 @@ export const DocumentTitleName = styled.div`
 `;
 
 export const DocumentCheckbox = styled.input.attrs({ type: 'checkbox' })`
-	width: 20px;
-	height: 20px;
+	width: 18px;
+	height: 18px;
 	cursor: pointer;
 	appearance: none;
 	border: 1.5px solid ${theme.color.border.iSecondary};
@@ -75,6 +75,7 @@ export const DocumentCheckbox = styled.input.attrs({ type: 'checkbox' })`
 
 export const DocumentStateContainer = styled.div`
 	display: flex;
+	grid-row: 1 / -1;
 	flex-direction: column;
 	justify-content: center;
 	align-items: center;
@@ -82,12 +83,26 @@ export const DocumentStateContainer = styled.div`
 	gap: ${theme.units.spacing.space16};
 `;
 
-export const NumberButtonWrapper = styled.div.withConfig({
-	shouldForwardProp: (prop) => prop !== 'active',
-})<{ active: boolean }>`
+export const DocumentListContainer = styled.div`
+	display: grid;
+	flex: 1;
+	grid-template-rows: repeat(10, minmax(36px, 1fr));
+	min-height: 396px;
+	gap: ${theme.units.spacing.space4};
+`;
+
+export const PaginationContainer = styled.div`
+	display: flex;
+	justify-content: center;
+	padding-bottom: ${theme.units.spacing.space24};
+`;
+
+export const NumberButtonWrapper = styled.div<{ $active: boolean }>`
 	button {
-		color: ${({ active }) =>
-			active ? `${theme.color.text.iPrimary}` : `${theme.color.text.tertiary}`};
+		color: ${({ $active }) =>
+			$active
+				? `${theme.color.text.iPrimary}`
+				: `${theme.color.text.tertiary}`};
 
 		&:hover {
 			color: ${theme.color.text.iPrimary};

--- a/src/pages/DocumentPage/DocumentPage.styled.ts
+++ b/src/pages/DocumentPage/DocumentPage.styled.ts
@@ -6,7 +6,7 @@ export const DocumentContainer = styled.div`
 	flex-direction: column;
 	width: 920px;
 	height: 100%;
-	overflow-x: none;
+	overflow-x: hidden;
 	gap: ${theme.units.spacing.space16};
 `;
 

--- a/src/pages/DocumentPage/DocumentPage.styled.ts
+++ b/src/pages/DocumentPage/DocumentPage.styled.ts
@@ -6,9 +6,15 @@ export const DocumentContainer = styled.div`
 	flex-direction: column;
 	width: 920px;
 	height: 100%;
-	padding: ${theme.units.spacing.space20} ${theme.units.spacing.space10};
 	overflow-x: none;
 	gap: ${theme.units.spacing.space16};
+`;
+
+export const DocumentHeader = styled.div`
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 24px 12px 16px 12px;
 `;
 
 export const DocumentTitleContainer = styled.div`

--- a/src/pages/DocumentPage/DocumentPage.styled.ts
+++ b/src/pages/DocumentPage/DocumentPage.styled.ts
@@ -82,7 +82,9 @@ export const DocumentStateContainer = styled.div`
 	gap: ${theme.units.spacing.space16};
 `;
 
-export const NumberButtonWrapper = styled.div<{ active: boolean }>`
+export const NumberButtonWrapper = styled.div.withConfig({
+	shouldForwardProp: (prop) => prop !== 'active',
+})<{ active: boolean }>`
 	button {
 		color: ${({ active }) =>
 			active ? `${theme.color.text.iPrimary}` : `${theme.color.text.tertiary}`};

--- a/src/pages/DocumentPage/DocumentPage.styled.ts
+++ b/src/pages/DocumentPage/DocumentPage.styled.ts
@@ -17,6 +17,12 @@ export const DocumentHeader = styled.div`
 	padding: 24px 12px 16px 12px;
 `;
 
+export const DocumentHeaderActions = styled.div`
+	display: flex;
+	align-items: center;
+	gap: ${theme.units.spacing.space12};
+`;
+
 export const DocumentTitleContainer = styled.div`
 	display: flex;
 	background-color: ${theme.color.bg.secondary};
@@ -28,6 +34,52 @@ export const DocumentTitleWrapper = styled.div<{ width: string }>`
 	justify-content: center;
 	align-items: center;
 	width: ${(props) => props.width || 'auto'};
+`;
+
+export const DocumentTitleName = styled.div`
+	display: flex;
+	align-items: center;
+	width: 100%;
+	gap: ${theme.units.spacing.space16};
+	padding: 0 ${theme.units.spacing.space6};
+`;
+
+export const DocumentCheckbox = styled.input.attrs({ type: 'checkbox' })`
+	width: 20px;
+	height: 20px;
+	cursor: pointer;
+	appearance: none;
+	border: 1.5px solid ${theme.color.border.iSecondary};
+	border-radius: ${theme.units.radius.radius2};
+
+	&:disabled {
+		cursor: default;
+		border-color: ${theme.color.border.disabled};
+		background-color: ${theme.color.bg.disabled};
+	}
+
+	&:checked {
+		background-color: ${theme.color.bg.iPrimary};
+		border-color: ${theme.color.border.iPrimary};
+	}
+
+	&:checked::after {
+		content: '✓';
+		font-size: ${theme.typography.fontSize.body.lg};
+		color: white;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+	}
+`;
+
+export const DocumentStateContainer = styled.div`
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	height: 100%;
+	gap: ${theme.units.spacing.space16};
 `;
 
 export const NumberButtonWrapper = styled.div<{ active: boolean }>`

--- a/src/pages/DocumentPage/DocumentPage.styled.ts
+++ b/src/pages/DocumentPage/DocumentPage.styled.ts
@@ -23,6 +23,10 @@ export const DocumentHeaderActions = styled.div`
 	gap: ${theme.units.spacing.space12};
 `;
 
+export const SelectWrapper = styled.div`
+	width: 120px;
+`;
+
 export const DocumentTitleContainer = styled.div`
 	display: flex;
 	background-color: ${theme.color.bg.secondary};

--- a/src/pages/DocumentPage/DocumentPage.styled.ts
+++ b/src/pages/DocumentPage/DocumentPage.styled.ts
@@ -65,7 +65,7 @@ export const DocumentCheckbox = styled.input.attrs({ type: 'checkbox' })`
 
 	&:checked::after {
 		content: '✓';
-		font-size: ${theme.typography.fontSize.body.lg};
+		font-size: ${theme.typography.fontSize.body.md};
 		color: white;
 		display: flex;
 		justify-content: center;

--- a/src/pages/DocumentPage/DocumentPage.tsx
+++ b/src/pages/DocumentPage/DocumentPage.tsx
@@ -16,7 +16,9 @@ const DocumentPage = () => {
 	const { teamDocument } = useDocumentQuery(
 		userStatus?.profile.lastSeenTeamspaceId
 	);
-	const [selectedDocument, setSelectedDocument] = useState<string[]>([]);
+	const [selectedDocument, setSelectedDocument] = useState<Set<string>>(
+		new Set()
+	);
 	const [selectedNumber, setSelectedNumber] = useState(1);
 
 	useEffect(() => {
@@ -32,7 +34,7 @@ const DocumentPage = () => {
 			window.open(fileUrl, '_blank');
 		});
 
-		setSelectedDocument([]);
+		setSelectedDocument(new Set());
 	};
 
 	const handleNumberClick = (number: number) => {
@@ -64,10 +66,12 @@ const DocumentPage = () => {
 
 	const handleDocumentClick = (fileUrl: string) => {
 		setSelectedDocument((prevSelected) => {
-			if (prevSelected.includes(fileUrl))
-				return prevSelected.filter((url) => url !== fileUrl);
+			const nextSelected = new Set(prevSelected);
 
-			return [...prevSelected, fileUrl];
+			if (nextSelected.has(fileUrl)) nextSelected.delete(fileUrl);
+			else nextSelected.add(fileUrl);
+
+			return nextSelected;
 		});
 	};
 
@@ -82,7 +86,7 @@ const DocumentPage = () => {
 					label='다운로드'
 					variant='secondary'
 					size='sm'
-					disabled={selectedDocument.length === 0}
+					disabled={selectedDocument.size === 0}
 					leadingIcon='Download'
 					onClick={handleDownloadClick}
 				/>

--- a/src/pages/DocumentPage/DocumentPage.tsx
+++ b/src/pages/DocumentPage/DocumentPage.tsx
@@ -24,7 +24,13 @@ const DocumentPage = () => {
 
 	const handleDownloadClick = () => {
 		selectedDocument.forEach((fileUrl) => {
-			window.open(fileUrl, '_blank');
+			const link = document.createElement('a');
+
+			link.href = fileUrl;
+			link.download = '';
+			document.body.appendChild(link);
+			link.click();
+			document.body.removeChild(link);
 		});
 
 		setSelectedDocument(new Set());

--- a/src/pages/DocumentPage/DocumentPage.tsx
+++ b/src/pages/DocumentPage/DocumentPage.tsx
@@ -135,12 +135,14 @@ const DocumentPage = () => {
 						ariaLabel='ChevronsLeft'
 						color='iSecondary'
 						onClick={() => handleArrowClick('left', true)}
+						disabled={selectedNumber === 1}
 					/>
 					<IconButton
 						icon='ChevronLeft'
 						ariaLabel='ChevronLeft'
 						color='iSecondary'
 						onClick={() => handleArrowClick('left')}
+						disabled={selectedNumber === 1}
 					/>
 					{teamDocument &&
 						Array.from(
@@ -168,12 +170,18 @@ const DocumentPage = () => {
 						ariaLabel='ChevronRight'
 						color='iSecondary'
 						onClick={() => handleArrowClick('right')}
+						disabled={
+							selectedNumber === Math.ceil(teamDocument.attachments.length / 5)
+						}
 					/>
 					<IconButton
 						icon='ChevronsRight'
 						ariaLabel='ChevronsRight'
 						color='iSecondary'
 						onClick={() => handleArrowClick('right', true)}
+						disabled={
+							selectedNumber === Math.ceil(teamDocument.attachments.length / 5)
+						}
 					/>
 				</Flex>
 			)}

--- a/src/pages/DocumentPage/DocumentPage.tsx
+++ b/src/pages/DocumentPage/DocumentPage.tsx
@@ -1,10 +1,11 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { Button } from '@components/common/Button/Button';
 import Divider from '@components/common/Divider/Divider';
 import Flex from '@components/common/Flex/Flex';
 import Heading from '@components/common/Heading/Heading';
 import Icon from '@components/common/Icon/Icon';
 import IconButton from '@components/common/IconButton/IconButton';
+import Select from '@components/common/Select/Select';
 import Text from '@components/common/Text/Text';
 import DocumentItem from '@components/Document/DocumentItem/DocumentItem';
 import useDocumentDownload from '@hooks/document/useDocumentDownload';
@@ -12,7 +13,10 @@ import useDocumentPagination from '@hooks/document/useDocumentPagination';
 import useDocumentSelection from '@hooks/document/useDocumentSelection';
 import useDocumentQuery from '@hooks/queries/document/useDocumentQuery';
 import useUserStatusQuery from '@hooks/queries/useUserStatusQuery';
-import { getLatestDocuments } from '@utils/document/documentSort';
+import {
+	type DocumentSortOrder,
+	getDocumentsBySortOrder,
+} from '@utils/document/getDocumentsBySortOrder';
 import { getUnitFormattedSize } from '@utils/getUnitFormattedSize';
 import * as S from './DocumentPage.styled';
 
@@ -20,15 +24,24 @@ const ITEMS_PER_PAGE = 10;
 const PAGE_GROUP_SIZE = 10;
 const DOWNLOAD_INTERVAL_MS = 300;
 const TOTAL_STORAGE_CAPACITY = 300 * 1024 * 1024 * 1024;
+const DOCUMENT_SORT_ORDER_MAP: Record<string, DocumentSortOrder> = {
+	최신순: 'latest',
+	오래된순: 'oldest',
+};
 
 const DocumentPage = () => {
+	const [selectedSortOption, setSelectedSortOption] = useState('최신순');
 	const { userStatus } = useUserStatusQuery();
 	const { teamDocument, isPending } = useDocumentQuery(
 		userStatus?.profile.lastSeenTeamspaceId
 	);
 	const attachments = useMemo(
-		() => getLatestDocuments(teamDocument?.attachments ?? []),
-		[teamDocument]
+		() =>
+			getDocumentsBySortOrder(
+				teamDocument?.attachments ?? [],
+				DOCUMENT_SORT_ORDER_MAP[selectedSortOption]
+			),
+		[teamDocument, selectedSortOption]
 	);
 	const usedStorageCapacity = teamDocument?.totalStorageCapacity ?? 0;
 	const {
@@ -56,6 +69,13 @@ const DocumentPage = () => {
 		downloadIntervalMs: DOWNLOAD_INTERVAL_MS,
 		onAfterDownload: clearSelectedDocument,
 	});
+
+	const handleSortSelect = (index: number) => {
+		setSelectedSortOption(
+			Object.keys(DOCUMENT_SORT_ORDER_MAP)[index - 1] ??
+				Object.keys(DOCUMENT_SORT_ORDER_MAP)[0]
+		);
+	};
 
 	return (
 		<S.DocumentContainer>
@@ -85,6 +105,14 @@ const DocumentPage = () => {
 							leadingIcon='Download'
 							onClick={handleDownloadClick}
 						/>
+						<S.SelectWrapper>
+							<Select
+								size='sm'
+								options={Object.keys(DOCUMENT_SORT_ORDER_MAP)}
+								select={selectedSortOption}
+								setSelect={handleSortSelect}
+							/>
+						</S.SelectWrapper>
 					</S.DocumentHeaderActions>
 				</S.DocumentHeader>
 				<Divider size='sm' />

--- a/src/pages/DocumentPage/DocumentPage.tsx
+++ b/src/pages/DocumentPage/DocumentPage.tsx
@@ -33,10 +33,7 @@ const DocumentPage = () => {
 		() => [...(teamDocument?.attachments ?? [])].reverse(),
 		[teamDocument]
 	);
-	const usedStorageCapacity = useMemo(
-		() => attachments.reduce((total, attachment) => total + attachment.size, 0),
-		[attachments]
-	);
+	const usedStorageCapacity = teamDocument?.totalStorageCapacity ?? 0;
 	const visibleAttachments = useMemo(
 		() =>
 			attachments.slice(

--- a/src/pages/DocumentPage/DocumentPage.tsx
+++ b/src/pages/DocumentPage/DocumentPage.tsx
@@ -1,20 +1,27 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Button } from '@components/common/Button/Button';
 import Divider from '@components/common/Divider/Divider';
 import Flex from '@components/common/Flex/Flex';
 import Heading from '@components/common/Heading/Heading';
+import Icon from '@components/common/Icon/Icon';
 import IconButton from '@components/common/IconButton/IconButton';
 import Text from '@components/common/Text/Text';
 import DocumentItem from '@components/Document/DocumentItem/DocumentItem';
 import useDocumentQuery from '@hooks/queries/document/useDocumentQuery';
 import useUserStatusQuery from '@hooks/queries/useUserStatusQuery';
+import { getUnitFormattedSize } from '@utils/getUnitFormattedSize';
 import * as S from './DocumentPage.styled';
 
 type PageDirection = 'prev' | 'next';
 
+const ITEMS_PER_PAGE = 5;
+const PAGE_GROUP_SIZE = 10;
+const DOWNLOAD_INTERVAL_MS = 300;
+const TOTAL_STORAGE_CAPACITY = 300 * 1024 * 1024 * 1024;
+
 const DocumentPage = () => {
 	const { userStatus } = useUserStatusQuery();
-	const { teamDocument } = useDocumentQuery(
+	const { teamDocument, isPending } = useDocumentQuery(
 		userStatus?.profile.lastSeenTeamspaceId
 	);
 	const [selectedDocument, setSelectedDocument] = useState<Set<string>>(
@@ -22,15 +29,42 @@ const DocumentPage = () => {
 	);
 	const [selectedNumber, setSelectedNumber] = useState(1);
 
-	const handleDownloadClick = () => {
-		selectedDocument.forEach((fileUrl) => {
-			const link = document.createElement('a');
+	const attachments = useMemo(
+		() => [...(teamDocument?.attachments ?? [])].reverse(),
+		[teamDocument]
+	);
+	const usedStorageCapacity = useMemo(
+		() => attachments.reduce((total, attachment) => total + attachment.size, 0),
+		[attachments]
+	);
+	const visibleAttachments = useMemo(
+		() =>
+			attachments.slice(
+				(selectedNumber - 1) * ITEMS_PER_PAGE,
+				selectedNumber * ITEMS_PER_PAGE
+			),
+		[attachments, selectedNumber]
+	);
+	const lastPageNumber = Math.ceil(attachments.length / ITEMS_PER_PAGE);
+	const selectedVisibleCount = visibleAttachments.filter((attachment) =>
+		selectedDocument.has(attachment.fileUrl)
+	).length;
+	const isAllVisibleSelected =
+		visibleAttachments.length > 0 &&
+		selectedVisibleCount === visibleAttachments.length;
 
-			link.href = fileUrl;
-			link.download = '';
-			document.body.appendChild(link);
-			link.click();
-			document.body.removeChild(link);
+	const handleDownloadClick = () => {
+		Array.from(selectedDocument).forEach((fileUrl, index) => {
+			window.setTimeout(() => {
+				const link = document.createElement('a');
+
+				link.href = fileUrl;
+				link.download = '';
+
+				document.body.appendChild(link);
+				link.click();
+				document.body.removeChild(link);
+			}, index * DOWNLOAD_INTERVAL_MS);
 		});
 
 		setSelectedDocument(new Set());
@@ -45,14 +79,19 @@ const DocumentPage = () => {
 	};
 
 	const handlePageGroupClick = (direction: PageDirection) => {
-		if (!teamDocument) return;
-
-		const lastPageNumber = Math.ceil(teamDocument.attachments.length / 5);
+		if (attachments.length === 0) return;
 
 		setSelectedNumber((prev) =>
 			direction === 'prev'
-				? Math.max((Math.floor((prev - 1) / 10) - 1) * 10 + 1, 1)
-				: Math.min(Math.ceil(prev / 10) * 10 + 1, lastPageNumber)
+				? Math.max(
+						(Math.floor((prev - 1) / PAGE_GROUP_SIZE) - 1) * PAGE_GROUP_SIZE +
+							1,
+						1
+					)
+				: Math.min(
+						Math.ceil(prev / PAGE_GROUP_SIZE) * PAGE_GROUP_SIZE + 1,
+						lastPageNumber
+					)
 		);
 	};
 
@@ -67,29 +106,69 @@ const DocumentPage = () => {
 		});
 	};
 
+	const handleSelectAllClick = () => {
+		setSelectedDocument((prevSelected) => {
+			const nextSelected = new Set(prevSelected);
+
+			if (isAllVisibleSelected) {
+				visibleAttachments.forEach((attachment) =>
+					nextSelected.delete(attachment.fileUrl)
+				);
+			} else {
+				visibleAttachments.forEach((attachment) =>
+					nextSelected.add(attachment.fileUrl)
+				);
+			}
+
+			return nextSelected;
+		});
+	};
+
 	return (
 		<S.DocumentContainer>
 			<Flex direction='column'>
 				<S.DocumentHeader>
-					<Heading size='xs' color='primary'>
-						자료 저장소
-					</Heading>
-					<Button
-						label='다운로드'
-						variant='secondary'
-						size='sm'
-						disabled={selectedDocument.size === 0}
-						leadingIcon='Download'
-						onClick={handleDownloadClick}
-					/>
+					<Flex direction='column' gap='8'>
+						<Heading size='xs' color='primary'>
+							자료 저장소
+						</Heading>
+						<Text size='sm' weight='regular' color='secondary'>
+							{`총 ${attachments.length}개 자료 · ${getUnitFormattedSize(
+								usedStorageCapacity
+							)} / ${getUnitFormattedSize(TOTAL_STORAGE_CAPACITY)} 사용 중`}
+						</Text>
+					</Flex>
+					<S.DocumentHeaderActions>
+						{selectedDocument.size > 0 && (
+							<Text size='sm' weight='medium' color='iPrimary'>
+								{`${selectedDocument.size}개 선택됨`}
+							</Text>
+						)}
+						<Button
+							label='다운로드'
+							variant='secondary'
+							size='sm'
+							disabled={selectedDocument.size === 0}
+							leadingIcon='Download'
+							onClick={handleDownloadClick}
+						/>
+					</S.DocumentHeaderActions>
 				</S.DocumentHeader>
 				<Divider size='sm' />
 			</Flex>
 			<S.DocumentTitleContainer>
 				<S.DocumentTitleWrapper width='45%'>
-					<Text size='lg' weight='medium'>
-						파일명
-					</Text>
+					<S.DocumentTitleName>
+						<S.DocumentCheckbox
+							aria-label='현재 페이지 자료 전체 선택'
+							checked={isAllVisibleSelected}
+							disabled={visibleAttachments.length === 0}
+							onChange={handleSelectAllClick}
+						/>
+						<Text size='lg' weight='medium'>
+							파일명
+						</Text>
+					</S.DocumentTitleName>
 				</S.DocumentTitleWrapper>
 				<S.DocumentTitleWrapper width='15%'>
 					<Text size='lg' weight='medium'>
@@ -108,21 +187,30 @@ const DocumentPage = () => {
 				</S.DocumentTitleWrapper>
 			</S.DocumentTitleContainer>
 			<Flex direction='column' gap='16' height='350'>
-				{teamDocument &&
-					teamDocument.attachments
-						.slice(
-							Math.floor(selectedNumber - 1) * 5,
-							Math.floor(selectedNumber - 1) * 5 + 5
-						)
-						.map((attachment) => (
-							<DocumentItem
-								attachment={attachment}
-								handleDocumentClick={handleDocumentClick}
-								selectedDocument={selectedDocument}
-							/>
-						))}
+				{!isPending && attachments.length === 0 && (
+					<S.DocumentStateContainer>
+						<Icon name='Folder' color='tertiary' size='lg' />
+						<Flex direction='column' align='center' gap='8'>
+							<Heading size='xs' color='primary'>
+								아직 저장된 자료가 없어요
+							</Heading>
+							<Text size='md' weight='regular' color='secondary'>
+								현재 팀스페이스의 피드와 채팅에서 주고받은 파일이 이곳에 모여요.
+							</Text>
+						</Flex>
+					</S.DocumentStateContainer>
+				)}
+				{!isPending &&
+					visibleAttachments.map((attachment) => (
+						<DocumentItem
+							key={attachment.id}
+							attachment={attachment}
+							handleDocumentClick={handleDocumentClick}
+							selectedDocument={selectedDocument}
+						/>
+					))}
 			</Flex>
-			{teamDocument && teamDocument.attachments.length > 0 && (
+			{attachments.length > 0 && (
 				<Flex justify='center'>
 					<IconButton
 						icon='ChevronsLeft'
@@ -138,44 +226,39 @@ const DocumentPage = () => {
 						onClick={() => handlePageClick('prev')}
 						disabled={selectedNumber === 1}
 					/>
-					{teamDocument &&
-						Array.from(
-							{ length: Math.ceil(teamDocument.attachments.length / 5) },
-							(_, index) => index + 1
+					{Array.from({ length: lastPageNumber }, (_, index) => index + 1)
+						.slice(
+							Math.floor((selectedNumber - 1) / PAGE_GROUP_SIZE) *
+								PAGE_GROUP_SIZE,
+							Math.floor((selectedNumber - 1) / PAGE_GROUP_SIZE) *
+								PAGE_GROUP_SIZE +
+								PAGE_GROUP_SIZE
 						)
-							.slice(
-								Math.floor((selectedNumber - 1) / 10) * 10,
-								Math.floor((selectedNumber - 1) / 10) * 10 + 10
-							)
-							.map((number) => (
-								<S.NumberButtonWrapper
-									active={selectedNumber === number}
-									key={number}>
-									<Button
-										label={number.toString()}
-										variant='text'
-										size='md'
-										onClick={() => handleNumberClick(number)}
-									/>
-								</S.NumberButtonWrapper>
-							))}
+						.map((number) => (
+							<S.NumberButtonWrapper
+								active={selectedNumber === number}
+								key={number}>
+								<Button
+									label={number.toString()}
+									variant='text'
+									size='md'
+									onClick={() => handleNumberClick(number)}
+								/>
+							</S.NumberButtonWrapper>
+						))}
 					<IconButton
 						icon='ChevronRight'
 						ariaLabel='ChevronRight'
 						color='iSecondary'
 						onClick={() => handlePageClick('next')}
-						disabled={
-							selectedNumber === Math.ceil(teamDocument.attachments.length / 5)
-						}
+						disabled={selectedNumber === lastPageNumber}
 					/>
 					<IconButton
 						icon='ChevronsRight'
 						ariaLabel='ChevronsRight'
 						color='iSecondary'
 						onClick={() => handlePageGroupClick('next')}
-						disabled={
-							selectedNumber === Math.ceil(teamDocument.attachments.length / 5)
-						}
+						disabled={selectedNumber === lastPageNumber}
 					/>
 				</Flex>
 			)}

--- a/src/pages/DocumentPage/DocumentPage.tsx
+++ b/src/pages/DocumentPage/DocumentPage.tsx
@@ -12,12 +12,12 @@ import useUserStatusQuery from '@hooks/queries/useUserStatusQuery';
 import { getUnitFormattedSize } from '@utils/getUnitFormattedSize';
 import * as S from './DocumentPage.styled';
 
-type PageDirection = 'prev' | 'next';
-
-const ITEMS_PER_PAGE = 5;
+const ITEMS_PER_PAGE = 10;
 const PAGE_GROUP_SIZE = 10;
 const DOWNLOAD_INTERVAL_MS = 300;
 const TOTAL_STORAGE_CAPACITY = 300 * 1024 * 1024 * 1024;
+
+type PageDirection = 'prev' | 'next';
 
 const DocumentPage = () => {
 	const { userStatus } = useUserStatusQuery();
@@ -140,7 +140,7 @@ const DocumentPage = () => {
 					</Flex>
 					<S.DocumentHeaderActions>
 						{selectedDocument.size > 0 && (
-							<Text size='sm' weight='medium' color='iPrimary'>
+							<Text size='sm' weight='medium' color='primary'>
 								{`${selectedDocument.size}개 선택됨`}
 							</Text>
 						)}
@@ -186,7 +186,7 @@ const DocumentPage = () => {
 					</Text>
 				</S.DocumentTitleWrapper>
 			</S.DocumentTitleContainer>
-			<Flex direction='column' gap='16' height='350'>
+			<S.DocumentListContainer>
 				{!isPending && attachments.length === 0 && (
 					<S.DocumentStateContainer>
 						<Icon name='Folder' color='tertiary' size='lg' />
@@ -209,9 +209,9 @@ const DocumentPage = () => {
 							selectedDocument={selectedDocument}
 						/>
 					))}
-			</Flex>
+			</S.DocumentListContainer>
 			{attachments.length > 0 && (
-				<Flex justify='center'>
+				<S.PaginationContainer>
 					<IconButton
 						icon='ChevronsLeft'
 						ariaLabel='ChevronsLeft'
@@ -236,7 +236,7 @@ const DocumentPage = () => {
 						)
 						.map((number) => (
 							<S.NumberButtonWrapper
-								active={selectedNumber === number}
+								$active={selectedNumber === number}
 								key={number}>
 								<Button
 									label={number.toString()}
@@ -260,7 +260,7 @@ const DocumentPage = () => {
 						onClick={() => handlePageGroupClick('next')}
 						disabled={selectedNumber === lastPageNumber}
 					/>
-				</Flex>
+				</S.PaginationContainer>
 			)}
 		</S.DocumentContainer>
 	);

--- a/src/pages/DocumentPage/DocumentPage.tsx
+++ b/src/pages/DocumentPage/DocumentPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { Button } from '@components/common/Button/Button';
 import Divider from '@components/common/Divider/Divider';
 import Flex from '@components/common/Flex/Flex';
@@ -7,8 +7,12 @@ import Icon from '@components/common/Icon/Icon';
 import IconButton from '@components/common/IconButton/IconButton';
 import Text from '@components/common/Text/Text';
 import DocumentItem from '@components/Document/DocumentItem/DocumentItem';
+import useDocumentDownload from '@hooks/document/useDocumentDownload';
+import useDocumentPagination from '@hooks/document/useDocumentPagination';
+import useDocumentSelection from '@hooks/document/useDocumentSelection';
 import useDocumentQuery from '@hooks/queries/document/useDocumentQuery';
 import useUserStatusQuery from '@hooks/queries/useUserStatusQuery';
+import { getLatestDocuments } from '@utils/document/documentSort';
 import { getUnitFormattedSize } from '@utils/getUnitFormattedSize';
 import * as S from './DocumentPage.styled';
 
@@ -17,109 +21,41 @@ const PAGE_GROUP_SIZE = 10;
 const DOWNLOAD_INTERVAL_MS = 300;
 const TOTAL_STORAGE_CAPACITY = 300 * 1024 * 1024 * 1024;
 
-type PageDirection = 'prev' | 'next';
-
 const DocumentPage = () => {
 	const { userStatus } = useUserStatusQuery();
 	const { teamDocument, isPending } = useDocumentQuery(
 		userStatus?.profile.lastSeenTeamspaceId
 	);
-	const [selectedDocument, setSelectedDocument] = useState<Set<string>>(
-		new Set()
-	);
-	const [selectedNumber, setSelectedNumber] = useState(1);
-
 	const attachments = useMemo(
-		() => [...(teamDocument?.attachments ?? [])].reverse(),
+		() => getLatestDocuments(teamDocument?.attachments ?? []),
 		[teamDocument]
 	);
 	const usedStorageCapacity = teamDocument?.totalStorageCapacity ?? 0;
-	const visibleAttachments = useMemo(
-		() =>
-			attachments.slice(
-				(selectedNumber - 1) * ITEMS_PER_PAGE,
-				selectedNumber * ITEMS_PER_PAGE
-			),
-		[attachments, selectedNumber]
-	);
-	const lastPageNumber = Math.ceil(attachments.length / ITEMS_PER_PAGE);
-	const selectedVisibleCount = visibleAttachments.filter((attachment) =>
-		selectedDocument.has(attachment.fileUrl)
-	).length;
-	const isAllVisibleSelected =
-		visibleAttachments.length > 0 &&
-		selectedVisibleCount === visibleAttachments.length;
-
-	const handleDownloadClick = () => {
-		Array.from(selectedDocument).forEach((fileUrl, index) => {
-			window.setTimeout(() => {
-				const link = document.createElement('a');
-
-				link.href = fileUrl;
-				link.download = '';
-
-				document.body.appendChild(link);
-				link.click();
-				document.body.removeChild(link);
-			}, index * DOWNLOAD_INTERVAL_MS);
-		});
-
-		setSelectedDocument(new Set());
-	};
-
-	const handleNumberClick = (number: number) => {
-		if (number !== selectedNumber) setSelectedNumber(number);
-	};
-
-	const handlePageClick = (direction: PageDirection) => {
-		setSelectedNumber((prev) => (direction === 'prev' ? prev - 1 : prev + 1));
-	};
-
-	const handlePageGroupClick = (direction: PageDirection) => {
-		if (attachments.length === 0) return;
-
-		setSelectedNumber((prev) =>
-			direction === 'prev'
-				? Math.max(
-						(Math.floor((prev - 1) / PAGE_GROUP_SIZE) - 1) * PAGE_GROUP_SIZE +
-							1,
-						1
-					)
-				: Math.min(
-						Math.ceil(prev / PAGE_GROUP_SIZE) * PAGE_GROUP_SIZE + 1,
-						lastPageNumber
-					)
-		);
-	};
-
-	const handleDocumentClick = (fileUrl: string) => {
-		setSelectedDocument((prevSelected) => {
-			const nextSelected = new Set(prevSelected);
-
-			if (nextSelected.has(fileUrl)) nextSelected.delete(fileUrl);
-			else nextSelected.add(fileUrl);
-
-			return nextSelected;
-		});
-	};
-
-	const handleSelectAllClick = () => {
-		setSelectedDocument((prevSelected) => {
-			const nextSelected = new Set(prevSelected);
-
-			if (isAllVisibleSelected) {
-				visibleAttachments.forEach((attachment) =>
-					nextSelected.delete(attachment.fileUrl)
-				);
-			} else {
-				visibleAttachments.forEach((attachment) =>
-					nextSelected.add(attachment.fileUrl)
-				);
-			}
-
-			return nextSelected;
-		});
-	};
+	const {
+		selectedNumber,
+		visibleAttachments,
+		lastPageNumber,
+		pageNumbers,
+		handleNumberClick,
+		handlePageClick,
+		handlePageGroupClick,
+	} = useDocumentPagination({
+		attachments,
+		itemsPerPage: ITEMS_PER_PAGE,
+		pageGroupSize: PAGE_GROUP_SIZE,
+	});
+	const {
+		selectedDocument,
+		isAllVisibleSelected,
+		handleDocumentClick,
+		handleSelectAllClick,
+		clearSelectedDocument,
+	} = useDocumentSelection({ visibleAttachments });
+	const { handleDownloadClick } = useDocumentDownload({
+		selectedDocument,
+		downloadIntervalMs: DOWNLOAD_INTERVAL_MS,
+		onAfterDownload: clearSelectedDocument,
+	});
 
 	return (
 		<S.DocumentContainer>
@@ -223,26 +159,18 @@ const DocumentPage = () => {
 						onClick={() => handlePageClick('prev')}
 						disabled={selectedNumber === 1}
 					/>
-					{Array.from({ length: lastPageNumber }, (_, index) => index + 1)
-						.slice(
-							Math.floor((selectedNumber - 1) / PAGE_GROUP_SIZE) *
-								PAGE_GROUP_SIZE,
-							Math.floor((selectedNumber - 1) / PAGE_GROUP_SIZE) *
-								PAGE_GROUP_SIZE +
-								PAGE_GROUP_SIZE
-						)
-						.map((number) => (
-							<S.NumberButtonWrapper
-								$active={selectedNumber === number}
-								key={number}>
-								<Button
-									label={number.toString()}
-									variant='text'
-									size='md'
-									onClick={() => handleNumberClick(number)}
-								/>
-							</S.NumberButtonWrapper>
-						))}
+					{pageNumbers.map((number) => (
+						<S.NumberButtonWrapper
+							$active={selectedNumber === number}
+							key={number}>
+							<Button
+								label={number.toString()}
+								variant='text'
+								size='md'
+								onClick={() => handleNumberClick(number)}
+							/>
+						</S.NumberButtonWrapper>
+					))}
 					<IconButton
 						icon='ChevronRight'
 						ariaLabel='ChevronRight'

--- a/src/pages/DocumentPage/DocumentPage.tsx
+++ b/src/pages/DocumentPage/DocumentPage.tsx
@@ -11,6 +11,8 @@ import useDocumentQuery from '@hooks/queries/document/useDocumentQuery';
 import useUserStatusQuery from '@hooks/queries/useUserStatusQuery';
 import * as S from './DocumentPage.styled';
 
+type PageDirection = 'prev' | 'next';
+
 const DocumentPage = () => {
 	const { userStatus } = useUserStatusQuery();
 	const { teamDocument } = useDocumentQuery(
@@ -41,27 +43,20 @@ const DocumentPage = () => {
 		if (number !== selectedNumber) setSelectedNumber(number);
 	};
 
-	const handleArrowClick = (direction: string, jump: boolean = false) => {
-		if (direction === 'left' && selectedNumber > 1) {
-			setSelectedNumber((prev) =>
-				jump
-					? Math.max((Math.floor((prev - 1) / 10) - 1) * 10 + 1, 1)
-					: prev - 1
-			);
-		} else if (
-			direction === 'right' &&
-			teamDocument &&
-			selectedNumber < Math.ceil(teamDocument.attachments.length / 5)
-		) {
-			setSelectedNumber((prev) =>
-				jump
-					? Math.min(
-							Math.ceil(prev / 10) * 10 + 1,
-							Math.ceil(teamDocument.attachments.length / 5)
-						)
-					: prev + 1
-			);
-		}
+	const handlePageClick = (direction: PageDirection) => {
+		setSelectedNumber((prev) => (direction === 'prev' ? prev - 1 : prev + 1));
+	};
+
+	const handlePageGroupClick = (direction: PageDirection) => {
+		if (!teamDocument) return;
+
+		const lastPageNumber = Math.ceil(teamDocument.attachments.length / 5);
+
+		setSelectedNumber((prev) =>
+			direction === 'prev'
+				? Math.max((Math.floor((prev - 1) / 10) - 1) * 10 + 1, 1)
+				: Math.min(Math.ceil(prev / 10) * 10 + 1, lastPageNumber)
+		);
 	};
 
 	const handleDocumentClick = (fileUrl: string) => {
@@ -77,19 +72,21 @@ const DocumentPage = () => {
 
 	return (
 		<S.DocumentContainer>
-			<Flex direction='column' gap='10'>
-				<Heading size='xs'>자료 저장소</Heading>
-				<Divider size='sm' padding={4} />
-			</Flex>
-			<Flex gap='16'>
-				<Button
-					label='다운로드'
-					variant='secondary'
-					size='sm'
-					disabled={selectedDocument.size === 0}
-					leadingIcon='Download'
-					onClick={handleDownloadClick}
-				/>
+			<Flex direction='column'>
+				<S.DocumentHeader>
+					<Heading size='xs' color='primary'>
+						자료 저장소
+					</Heading>
+					<Button
+						label='다운로드'
+						variant='secondary'
+						size='sm'
+						disabled={selectedDocument.size === 0}
+						leadingIcon='Download'
+						onClick={handleDownloadClick}
+					/>
+				</S.DocumentHeader>
+				<Divider size='sm' />
 			</Flex>
 			<S.DocumentTitleContainer>
 				<S.DocumentTitleWrapper width='45%'>
@@ -134,14 +131,14 @@ const DocumentPage = () => {
 						icon='ChevronsLeft'
 						ariaLabel='ChevronsLeft'
 						color='iSecondary'
-						onClick={() => handleArrowClick('left', true)}
+						onClick={() => handlePageGroupClick('prev')}
 						disabled={selectedNumber === 1}
 					/>
 					<IconButton
 						icon='ChevronLeft'
 						ariaLabel='ChevronLeft'
 						color='iSecondary'
-						onClick={() => handleArrowClick('left')}
+						onClick={() => handlePageClick('prev')}
 						disabled={selectedNumber === 1}
 					/>
 					{teamDocument &&
@@ -169,7 +166,7 @@ const DocumentPage = () => {
 						icon='ChevronRight'
 						ariaLabel='ChevronRight'
 						color='iSecondary'
-						onClick={() => handleArrowClick('right')}
+						onClick={() => handlePageClick('next')}
 						disabled={
 							selectedNumber === Math.ceil(teamDocument.attachments.length / 5)
 						}
@@ -178,7 +175,7 @@ const DocumentPage = () => {
 						icon='ChevronsRight'
 						ariaLabel='ChevronsRight'
 						color='iSecondary'
-						onClick={() => handleArrowClick('right', true)}
+						onClick={() => handlePageGroupClick('next')}
 						disabled={
 							selectedNumber === Math.ceil(teamDocument.attachments.length / 5)
 						}

--- a/src/pages/DocumentPage/DocumentPage.tsx
+++ b/src/pages/DocumentPage/DocumentPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Button } from '@components/common/Button/Button';
 import Divider from '@components/common/Divider/Divider';
 import Flex from '@components/common/Flex/Flex';
@@ -6,7 +6,6 @@ import Heading from '@components/common/Heading/Heading';
 import IconButton from '@components/common/IconButton/IconButton';
 import Text from '@components/common/Text/Text';
 import DocumentItem from '@components/Document/DocumentItem/DocumentItem';
-import { queryClient } from '@hooks/queries/common/queryClient';
 import useDocumentQuery from '@hooks/queries/document/useDocumentQuery';
 import useUserStatusQuery from '@hooks/queries/useUserStatusQuery';
 import * as S from './DocumentPage.styled';
@@ -22,14 +21,6 @@ const DocumentPage = () => {
 		new Set()
 	);
 	const [selectedNumber, setSelectedNumber] = useState(1);
-
-	useEffect(() => {
-		return () => {
-			queryClient.invalidateQueries({
-				queryKey: ['teamDocument', userStatus?.profile.lastSeenTeamspaceId],
-			});
-		};
-	});
 
 	const handleDownloadClick = () => {
 		selectedDocument.forEach((fileUrl) => {

--- a/src/pages/DocumentPage/__tests__/DocumentPage.test.tsx
+++ b/src/pages/DocumentPage/__tests__/DocumentPage.test.tsx
@@ -105,6 +105,29 @@ describe('DocumentPage', () => {
 		);
 	});
 
+	test('정렬 옵션을 오래된순으로 변경하면 오래된 자료부터 보여줘야 한다', async () => {
+		const user = userEvent.setup();
+		mockDocumentQuery([
+			createAttachment(1, 'old-file.pdf', '2026-05-01T00:00:00'),
+			createAttachment(2, 'new-file.pdf', '2026-05-02T00:00:00'),
+		]);
+
+		const { container } = render(
+			<ThemeProvider theme={theme}>
+				<DocumentPage />
+			</ThemeProvider>
+		);
+
+		await user.click(screen.getByRole('button', { name: '최신순' }));
+		await user.click(screen.getByText('오래된순'));
+
+		const pageText = container.textContent ?? '';
+
+		expect(pageText.indexOf('old-file.pdf')).toBeLessThan(
+			pageText.indexOf('new-file.pdf')
+		);
+	});
+
 	test('파일을 선택하면 선택 개수를 보여주고 다운로드 버튼을 활성화해야 한다', async () => {
 		const user = userEvent.setup();
 		mockDocumentQuery([

--- a/src/pages/DocumentPage/__tests__/DocumentPage.test.tsx
+++ b/src/pages/DocumentPage/__tests__/DocumentPage.test.tsx
@@ -127,7 +127,7 @@ describe('DocumentPage', () => {
 	test('전체 선택은 현재 페이지 파일을 모두 선택하고 다시 누르면 해제해야 한다', async () => {
 		const user = userEvent.setup();
 		mockDocumentQuery(
-			Array.from({ length: 6 }, (_, index) =>
+			Array.from({ length: 11 }, (_, index) =>
 				createAttachment(
 					index + 1,
 					`${index + 1}번 파일.pdf`,
@@ -143,12 +143,12 @@ describe('DocumentPage', () => {
 
 		await user.click(selectAllCheckbox);
 
-		expect(screen.getByText('5개 선택됨')).toBeInTheDocument();
+		expect(screen.getByText('10개 선택됨')).toBeInTheDocument();
 		expect(selectAllCheckbox).toBeChecked();
 
 		await user.click(selectAllCheckbox);
 
-		expect(screen.queryByText('5개 선택됨')).not.toBeInTheDocument();
+		expect(screen.queryByText('10개 선택됨')).not.toBeInTheDocument();
 		expect(selectAllCheckbox).not.toBeChecked();
 	});
 });

--- a/src/pages/DocumentPage/__tests__/DocumentPage.test.tsx
+++ b/src/pages/DocumentPage/__tests__/DocumentPage.test.tsx
@@ -1,0 +1,154 @@
+import useDocumentQuery from '@hooks/queries/document/useDocumentQuery';
+import useUserStatusQuery from '@hooks/queries/useUserStatusQuery';
+import DocumentPage from '@pages/DocumentPage/DocumentPage';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from 'styled-components';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import theme from '@styles/theme';
+import type { Document } from '@type/document';
+
+vi.mock('@hooks/queries/document/useDocumentQuery');
+vi.mock('@hooks/queries/useUserStatusQuery');
+
+const mockedUseDocumentQuery = vi.mocked(useDocumentQuery);
+const mockedUseUserStatusQuery = vi.mocked(useUserStatusQuery);
+
+const createAttachment = (
+	id: number,
+	name: string,
+	createdAt: string
+): Document => ({
+	id,
+	name,
+	type: 'pdf',
+	size: 1024,
+	attachType: 'DOCUMENT',
+	fileUrl: `https://example.com/${id}`,
+	createdAt,
+	author: {
+		id,
+		username: `사용자${id}`,
+		profileImageUrl: null,
+	},
+});
+
+const mockUserStatus = () => {
+	mockedUseUserStatusQuery.mockReturnValue({
+		userStatus: {
+			profile: {
+				userId: 1,
+				username: '테스트 사용자',
+				profileImageUrl: null,
+				email: 'test@example.com',
+				emailSubscription: false,
+				commentNotification: 'NONE',
+				lastSeenTeamspaceId: 1,
+			},
+			participatedTeamspaces: [],
+		},
+	});
+};
+
+const mockDocumentQuery = (attachments: Document[]) => {
+	mockedUseDocumentQuery.mockReturnValue({
+		teamDocument: {
+			totalStorageCapacity: 0,
+			attachments,
+		},
+		isPending: false,
+	});
+};
+
+const renderDocumentPage = () => {
+	render(
+		<ThemeProvider theme={theme}>
+			<DocumentPage />
+		</ThemeProvider>
+	);
+};
+
+describe('DocumentPage', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockUserStatus();
+	});
+
+	test('자료가 없으면 빈 상태 문구를 보여줘야 한다', () => {
+		mockDocumentQuery([]);
+
+		renderDocumentPage();
+
+		expect(screen.getByText('아직 저장된 자료가 없어요')).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				'현재 팀스페이스의 피드와 채팅에서 주고받은 파일이 이곳에 모여요.'
+			)
+		).toBeInTheDocument();
+	});
+
+	test('파일 목록은 최신순으로 보여줘야 한다', () => {
+		mockDocumentQuery([
+			createAttachment(1, '오래된 파일.pdf', '2026-05-01T00:00:00'),
+			createAttachment(2, '최신 파일.pdf', '2026-05-02T00:00:00'),
+		]);
+
+		const { container } = render(
+			<ThemeProvider theme={theme}>
+				<DocumentPage />
+			</ThemeProvider>
+		);
+		const pageText = container.textContent ?? '';
+
+		expect(pageText.indexOf('최신 파일.pdf')).toBeLessThan(
+			pageText.indexOf('오래된 파일.pdf')
+		);
+	});
+
+	test('파일을 선택하면 선택 개수를 보여주고 다운로드 버튼을 활성화해야 한다', async () => {
+		const user = userEvent.setup();
+		mockDocumentQuery([
+			createAttachment(1, '첫 번째 파일.pdf', '2026-05-01T00:00:00'),
+		]);
+
+		renderDocumentPage();
+
+		const downloadButton = screen.getByRole('button', { name: '다운로드' });
+		const [, documentCheckbox] = screen.getAllByRole('checkbox');
+
+		expect(downloadButton).toBeDisabled();
+
+		await user.click(documentCheckbox);
+
+		expect(screen.getByText('1개 선택됨')).toBeInTheDocument();
+		expect(downloadButton).toBeEnabled();
+	});
+
+	test('전체 선택은 현재 페이지 파일을 모두 선택하고 다시 누르면 해제해야 한다', async () => {
+		const user = userEvent.setup();
+		mockDocumentQuery(
+			Array.from({ length: 6 }, (_, index) =>
+				createAttachment(
+					index + 1,
+					`${index + 1}번 파일.pdf`,
+					`2026-05-${String(index + 1).padStart(2, '0')}T00:00:00`
+				)
+			)
+		);
+
+		renderDocumentPage();
+
+		const selectAllCheckbox =
+			screen.getByLabelText('현재 페이지 자료 전체 선택');
+
+		await user.click(selectAllCheckbox);
+
+		expect(screen.getByText('5개 선택됨')).toBeInTheDocument();
+		expect(selectAllCheckbox).toBeChecked();
+
+		await user.click(selectAllCheckbox);
+
+		expect(screen.queryByText('5개 선택됨')).not.toBeInTheDocument();
+		expect(selectAllCheckbox).not.toBeChecked();
+	});
+});

--- a/src/utils/document/documentPagination.ts
+++ b/src/utils/document/documentPagination.ts
@@ -1,0 +1,36 @@
+import type { Document } from '@type/document';
+
+export const getLastPageNumber = (
+	documentCount: number,
+	itemsPerPage: number
+) => {
+	return Math.max(Math.ceil(documentCount / itemsPerPage), 1);
+};
+
+export const getVisibleDocuments = (
+	documents: Document[],
+	selectedPage: number,
+	itemsPerPage: number
+) => {
+	return documents.slice(
+		(selectedPage - 1) * itemsPerPage,
+		selectedPage * itemsPerPage
+	);
+};
+
+export const getDocumentPageNumbers = (
+	selectedPage: number,
+	lastPage: number,
+	pageGroupSize: number
+) => {
+	const startPage =
+		Math.floor((selectedPage - 1) / pageGroupSize) * pageGroupSize + 1;
+	const endPage = Math.min(startPage + pageGroupSize - 1, lastPage);
+
+	return Array.from(
+		{ length: Math.max(endPage - startPage + 1, 0) },
+		(_, index) => {
+			return startPage + index;
+		}
+	);
+};

--- a/src/utils/document/documentSort.ts
+++ b/src/utils/document/documentSort.ts
@@ -1,0 +1,5 @@
+import type { Document } from '@type/document';
+
+export const getLatestDocuments = (documents: Document[]) => {
+	return [...documents].reverse();
+};

--- a/src/utils/document/documentSort.ts
+++ b/src/utils/document/documentSort.ts
@@ -1,5 +1,0 @@
-import type { Document } from '@type/document';
-
-export const getLatestDocuments = (documents: Document[]) => {
-	return [...documents].reverse();
-};

--- a/src/utils/document/getDocumentsBySortOrder.ts
+++ b/src/utils/document/getDocumentsBySortOrder.ts
@@ -1,0 +1,12 @@
+import type { Document } from '@type/document';
+
+export type DocumentSortOrder = 'latest' | 'oldest';
+
+export const getDocumentsBySortOrder = (
+	documents: Document[],
+	sortOrder: DocumentSortOrder
+) => {
+	if (sortOrder === 'latest') return [...documents].reverse();
+
+	return [...documents];
+};

--- a/src/utils/getUnitFormattedSize.ts
+++ b/src/utils/getUnitFormattedSize.ts
@@ -1,9 +1,9 @@
 export const getUnitFormattedSize = (size: number) => {
-	const units = ['B', 'KB', 'MB'];
+	const units = ['B', 'KB', 'MB', 'GB'];
 	let formattedSize = size;
 	let unitIndex = 0;
 
-	while (formattedSize >= 1024) {
+	while (formattedSize >= 1024 && unitIndex < units.length - 1) {
 		formattedSize /= 1024;
 		unitIndex += 1;
 	}


### PR DESCRIPTION
## 📌 관련 이슈

  - closed: https://github.com/98OO/colla-frontend/issues/211

  ## ✨ PR 세부 내용

  자료저장소의 UI와 기능 흐름을 리팩토링하고, 주요 동작을 테스트로 검증했습니다.

  **자료저장소 UI 개선**
  - 자료저장소 헤더에 전체 자료 개수와 사용 중인 저장 용량을 표시했습니다.
  - 자료가 없을 때 빈 상태 UI를 표시하도록 추가했습니다.
  - 문서 아이템에서 긴 파일명은 말줄임 처리하고, 전체 파일명은 `title`로 확인할 수 있도록 개선했습니다.
  - 공통 `Button`, `IconButton`의 비활성 상태 스타일을 정리했습니다.

  **자료저장소 기능 흐름 개선**
  - 문서 선택 상태를 `Set` 기반으로 관리하도록 정리했습니다.
  - 현재 페이지 자료 전체 선택/해제 기능을 추가했습니다.
  - 선택된 자료 개수를 표시하고, 선택 여부에 따라 다운로드 버튼 상태가 바뀌도록 개선했습니다.
  - 여러 파일 다운로드 시 요청 간격을 두도록 처리했습니다.
  - 업로드 파일 다운로드 시 파일명을 유지하도록 처리했습니다.

  **자료저장소 코드 정리**
  - 페이지당 항목 수, 페이지 그룹 크기, 다운로드 간격 등 주요 값을 상수화했습니다.
  - 자료 목록, 현재 페이지 자료, 사용 용량 계산을 `useMemo`로 분리했습니다.
  - 문서 조회 훅에서 로딩 상태를 함께 반환하도록 정리했습니다.
  - 용량 포맷터가 GB 단위까지 처리하도록 확장했습니다.
  - styled-components의 `active` prop이 DOM으로 전달되지 않도록 처리했습니다.

  **테스트**
  - 빈 상태 표시 검증
  - 최신순 목록 표시 검증
  - 파일 선택 시 선택 개수 및 다운로드 버튼 활성화 검증
  - 현재 페이지 전체 선택/해제 동작 검증

  ## 📸 스크린샷

<img width="1917" height="865" alt="image" src="https://github.com/user-attachments/assets/2e513b2f-441b-42cf-a0af-1535ea0715cd" />

<img width="1915" height="863" alt="image" src="https://github.com/user-attachments/assets/4b059d22-85e7-43f8-b07a-012374a5ed1f" />

  ## ✅ 리뷰 요구사항

  - 전체 선택은 전체 자료가 아니라 현재 페이지에 표시된 자료만 대상으로 동작합니다.
  - 다운로드 요청은 브라우저에서 여러 파일 다운로드가 누락되지 않도록 일정 간격을 두고 실행합니다.
  - 자료저장소 관련 테스트는 `DocumentPage.test.tsx`에 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 문서 목록에 페이지네이션 추가
  * 문서 정렬 옵션 추가 (최신순/오래된순)
  * 다중 문서 선택 및 일괄 다운로드 기능 개선

* **Bug Fixes**
  * 파일 업로드 시 파일명 인코딩 처리 개선
  * 스토리지 용량 표시 단위 확대 (GB 지원)

* **Style**
  * 문서 목록 UI 레이아웃 및 간격 최적화
  * 버튼 상태 표시 개선 (비활성 상태 시각화)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->