### PR TITLE
일정 조율 작성 흐름의 잠재 버그 수정 및 방어 코드 보강

### DIFF
--- a/src/components/Post/CollectPost/CollectPost.tsx
+++ b/src/components/Post/CollectPost/CollectPost.tsx
@@ -9,13 +9,16 @@ import DatePicker from '@components/Post/DatePicker/DatePicker';
 import Editor from '@components/Post/Editor/Editor';
 import usePostEditor from '@hooks/post/usePostEditor';
 import getDefaultDueAt from '@utils/post/scheduling/getDefaultDueAt';
+import isPastTime from '@utils/post/scheduling/isPastTime';
+import useToastStore from '@stores/toastStore';
 import { PATH } from '@constants/path';
-import { USER_CONFIRM_MESSAGE } from '@constants/post';
+import { DUE_AT_PAST_MESSAGE, USER_CONFIRM_MESSAGE } from '@constants/post';
 import type { DateString, TimeString } from '@type/post';
 import * as S from './CollectPost.styled';
 
 const CollectPost = () => {
 	const navigate = useNavigate();
+	const { makeToast } = useToastStore();
 	const {
 		editorRef,
 		attachmentFiles,
@@ -38,6 +41,11 @@ const CollectPost = () => {
 	};
 
 	const handleSubmit = async () => {
+		if (isPastTime(selectedDate, time)) {
+			makeToast(DUE_AT_PAST_MESSAGE, 'Warning');
+			return;
+		}
+
 		await submitCollectFeedForm(title, `${selectedDate} ${time}`);
 	};
 

--- a/src/components/Post/DatePicker/DatePicker.tsx
+++ b/src/components/Post/DatePicker/DatePicker.tsx
@@ -39,7 +39,6 @@ const DatePicker = ({ selectedDate, time, onDateChange, onTimeChange }: DatePick
 
 		const nextTimeOptions = getAvailableTimeOptions(date);
 
-		// 날짜를 변경했을 때 기존에 고른 시간이 유효하지 않을 경우 첫 유효 옵션으로 보정
 		if (!nextTimeOptions.includes(time)) {
 			onTimeChange(nextTimeOptions[0]);
 		}
@@ -111,6 +110,7 @@ const DatePicker = ({ selectedDate, time, onDateChange, onTimeChange }: DatePick
 					size='sm'
 					options={timeOptions}
 					select={time}
+					disabled={timeOptions.length === 0}
 					setSelect={(idx) => onTimeChange(timeOptions[idx - 1])}
 				/>
 			</Flex>

--- a/src/components/Post/SchedulingPost/Calendar/Calendar.stories.tsx
+++ b/src/components/Post/SchedulingPost/Calendar/Calendar.stories.tsx
@@ -34,13 +34,6 @@ const CalendarStateWrapper = ({ initialDates = [] }: { initialDates?: string[] }
 	return <Calendar selectedDates={selectedDates} setSelectedDates={setSelectedDates} />;
 };
 
-const getFutureDate = (daysFromNow: number) => {
-	const date = new Date();
-	date.setDate(date.getDate() + daysFromNow);
-
-	return date;
-};
-
 // --- Visual states ---
 
 export const Default: Story = {
@@ -63,7 +56,9 @@ export const ClickSelect: Story = {
 	render: () => <CalendarStateWrapper />,
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		const cell = canvas.getByText(getFutureDate(1).getDate().toString());
+
+		await userEvent.click(canvas.getByLabelText('nextMonth'));
+		const cell = canvas.getByText('1');
 
 		await userEvent.click(cell);
 		await expect(cell).toHaveAttribute('aria-selected', 'true');
@@ -77,17 +72,19 @@ export const DragSelect: Story = {
 	render: () => <CalendarStateWrapper />,
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		const cell1 = canvas.getByText(getFutureDate(1).getDate().toString());
-		const cell2 = canvas.getByText(getFutureDate(2).getDate().toString());
-		const cell3 = canvas.getByText(getFutureDate(3).getDate().toString());
 
-		fireEvent.pointerDown(cell1);
-		fireEvent.pointerOver(cell2);
-		fireEvent.pointerOver(cell3);
-		fireEvent.pointerUp(cell3);
+		await userEvent.click(canvas.getByLabelText('nextMonth'));
+		const startCell = canvas.getByText('1');
+		const midCell = canvas.getByText('2');
+		const endCell = canvas.getByText('3');
 
-		await expect(cell1).toHaveAttribute('aria-selected', 'true');
-		await expect(cell2).toHaveAttribute('aria-selected', 'true');
-		await expect(cell3).toHaveAttribute('aria-selected', 'true');
+		fireEvent.pointerDown(startCell);
+		fireEvent.pointerOver(midCell);
+		fireEvent.pointerOver(endCell);
+		fireEvent.pointerUp(endCell);
+
+		await expect(startCell).toHaveAttribute('aria-selected', 'true');
+		await expect(midCell).toHaveAttribute('aria-selected', 'true');
+		await expect(endCell).toHaveAttribute('aria-selected', 'true');
 	},
 };

--- a/src/components/Post/SchedulingPost/Step/SetConditionStep.tsx
+++ b/src/components/Post/SchedulingPost/Step/SetConditionStep.tsx
@@ -6,6 +6,7 @@ import TimeRangeSection from '@components/Post/SchedulingPost/Section/TimeRangeS
 import TitleSection from '@components/Post/SchedulingPost/Section/TitleSection';
 import isPastTime from '@utils/post/scheduling/isPastTime';
 import useToastStore from '@stores/toastStore';
+import { DUE_AT_PAST_MESSAGE } from '@constants/post';
 import type { DateString, SchedulingCondition, TimeString, TimeRange } from '@type/post';
 
 interface SetConditionProps {
@@ -58,7 +59,7 @@ const SetConditionStep = ({
 		const { dueAtDate, dueAtTime } = conditionRef.current;
 
 		if (isPastTime(dueAtDate, dueAtTime)) {
-			makeToast('마감 일시가 이미 지났어요. 날짜를 다시 선택해 주세요', 'Warning');
+			makeToast(DUE_AT_PAST_MESSAGE, 'Warning');
 			return;
 		}
 

--- a/src/components/Post/SchedulingPost/Step/SetConditionStep.tsx
+++ b/src/components/Post/SchedulingPost/Step/SetConditionStep.tsx
@@ -4,6 +4,8 @@ import Flex from '@components/common/Flex/Flex';
 import DueAtSection from '@components/Post/SchedulingPost/Section/DueAtSection';
 import TimeRangeSection from '@components/Post/SchedulingPost/Section/TimeRangeSection';
 import TitleSection from '@components/Post/SchedulingPost/Section/TitleSection';
+import isPastTime from '@utils/post/scheduling/isPastTime';
+import useToastStore from '@stores/toastStore';
 import type { DateString, SchedulingCondition, TimeString, TimeRange } from '@type/post';
 
 interface SetConditionProps {
@@ -26,6 +28,7 @@ const SetConditionStep = ({
 	onSubmit,
 }: SetConditionProps) => {
 	const [isSubmitAttempted, setIsSubmitAttempted] = useState(false);
+	const { makeToast } = useToastStore();
 
 	const conditionRef = useRef<SchedulingCondition>({
 		title: initialTitle,
@@ -49,6 +52,13 @@ const SetConditionStep = ({
 	const handleSubmit = () => {
 		if (!conditionRef.current.title.trim()) {
 			setIsSubmitAttempted(true);
+			return;
+		}
+
+		const { dueAtDate, dueAtTime } = conditionRef.current;
+
+		if (isPastTime(dueAtDate, dueAtTime)) {
+			makeToast('마감 일시가 이미 지났어요. 날짜를 다시 선택해 주세요', 'Warning');
 			return;
 		}
 

--- a/src/constants/post.ts
+++ b/src/constants/post.ts
@@ -14,3 +14,5 @@ export const DEFAULT_TIME_RANGE: TimeRange = {
 export const DEFAULT_DUE_TIME = resolveTimeOption(DEFAULT_TIME_OPTIONS, '18:00');
 
 export const USER_CONFIRM_MESSAGE = '작성 중인 내용이 있습니다. 정말 취소하시겠습니까?';
+
+export const DUE_AT_PAST_MESSAGE = '마감 일시가 이미 지났어요. 날짜를 다시 선택해 주세요';

--- a/src/hooks/common/funnel/useFunnel.tsx
+++ b/src/hooks/common/funnel/useFunnel.tsx
@@ -34,7 +34,8 @@ const useFunnel = <T extends string>(steps: readonly [T, ...T[]]) => {
 		setStep((curStep) => {
 			const curIndex = stepIndexMap.get(curStep);
 
-			if (curIndex === undefined || curIndex <= 0) return curStep;
+			if (curIndex === undefined) return steps[0];
+			if (curIndex <= 0) return curStep;
 
 			return steps[curIndex - 1];
 		});
@@ -44,7 +45,8 @@ const useFunnel = <T extends string>(steps: readonly [T, ...T[]]) => {
 		setStep((curStep) => {
 			const curIndex = stepIndexMap.get(curStep);
 
-			if (curIndex === undefined || curIndex >= steps.length - 1) return curStep;
+			if (curIndex === undefined) return steps[0];
+			if (curIndex >= steps.length - 1) return curStep;
 
 			return steps[curIndex + 1];
 		});

--- a/src/hooks/common/funnel/useFunnel.tsx
+++ b/src/hooks/common/funnel/useFunnel.tsx
@@ -32,7 +32,9 @@ const useFunnel = <T extends string>(steps: readonly [T, ...T[]]) => {
 
 	const prev = useCallback(() => {
 		setStep((curStep) => {
-			const curIndex = stepIndexMap.get(curStep)!;
+			const curIndex = stepIndexMap.get(curStep);
+
+			if (curIndex === undefined || curIndex <= 0) return curStep;
 
 			return steps[curIndex - 1];
 		});
@@ -40,7 +42,9 @@ const useFunnel = <T extends string>(steps: readonly [T, ...T[]]) => {
 
 	const next = useCallback(() => {
 		setStep((curStep) => {
-			const curIndex = stepIndexMap.get(curStep)!;
+			const curIndex = stepIndexMap.get(curStep);
+
+			if (curIndex === undefined || curIndex >= steps.length - 1) return curStep;
 
 			return steps[curIndex + 1];
 		});

--- a/src/hooks/queries/post/useSchedulingPostMutation.tsx
+++ b/src/hooks/queries/post/useSchedulingPostMutation.tsx
@@ -32,7 +32,10 @@ const useSchedulingPostMutation = () => {
 	});
 
 	const mutateSchedulingPost = async (formData: SchedulingPostFormData) => {
-		if (!teamspaceId) return;
+		if (teamspaceId === undefined) {
+			makeToast('팀스페이스 정보를 찾을 수 없어요. 다시 시도해 주세요', 'Warning');
+			return;
+		}
 
 		const convertedFormData: SchedulingPostRequest = {
 			title: formData.title,

--- a/src/utils/post/scheduling/isPastTime.ts
+++ b/src/utils/post/scheduling/isPastTime.ts
@@ -2,8 +2,11 @@ import { DateManager } from '@utils/common/DateManager';
 import type { DateString, TimeString } from '@type/post';
 
 const isPastTime = (target: DateString, time: TimeString, base = new Date()): boolean => {
-	if (DateManager.isPastDate(new Date(target), base)) return true;
-	if (!DateManager.isToday(new Date(target), base)) return false;
+	const [year, month, day] = target.split('-').map(Number);
+	const targetDate = new Date(year, month - 1, day);
+
+	if (DateManager.isPastDate(targetDate, base)) return true;
+	if (!DateManager.isToday(targetDate, base)) return false;
 
 	const [hours, minutes] = time.split(':').map(Number);
 	const baseMinutes = base.getHours() * 60 + base.getMinutes();


### PR DESCRIPTION
## 📌 관련 이슈

- https://github.com/98OO/colla-frontend/issues/201

## ✨ PR 세부 내용

일정 조율 작성 PR의 리뷰 코멘트들을 검토하고, 유효한 항목을 수정했습니다

**마감 일시가 과거가 되는 엣지 케이스 처리**
- 작성 중 시간이 흘러 (예: 자정 경과) 선택한 마감 일시가 과거가 되는 엣지 케이스가 있었습니다.
- 등록 시 과거 여부를 검증해 네트워크 요청 전에 차단하고, 토스트로 날짜 재선택을 안내하도록 수정했습니다.
- 선택 가능한 시간 옵션이 없을 때 `Select`를 비활성화 했습니다.

**날짜 문자열을 로컬 기준으로 파싱**

- `new Date('YYYY-MM-DD')`가 `UTC` 자정으로 해석해 음수 오프셋 환경에서 로컬 날짜가 하루 밀려 과거/오늘 판정이 어긋나는 잠재적인 버그가 있었습니다.
- 로컬 기준으로 생성한 문자열에 맞게 로컬 기준으로 동일하게 처리하도록 수정했습니다.

**퍼널 prev/next 경계 가드**

- 현재는 경계를 막고 있어 실제로 도달하진 않지만, 공용 훅의 방어 차원에서 가드를 추가했습니다.

**teamspaceId 누락 시 사용자 알림**

- teamspaceId가 없는데 작성 버튼을 눌렀을 경우 사용자에게 피드백 없이 에러를 처리하고 있어 경고 토스트를 띄우도록 수정했습니다.

**Calendar 인터렉션 테스트의 월 경계 불안정성 제거**

- 월말에 다음 달로 넘어가, 현재 렌더된 달에서 셀을 찾지 못하는 버그가 있었습니다.
- 다음 달로 이동 후 항상 존재하고 미래인 고정 날짜를 사용하도록 수정했습니다.

## ✅ 리뷰 요구사항
`DateCell` 컴포넌트의 키보드 접근성 처리는 버그 수정 PR의 범위를 벗어나므로 별도로 처리하겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 선택 가능한 시간이 없을 때 시간 선택 UI가 비활성화됩니다.
  * 마감 일시가 과거일 경우 경고를 표시하고 제출/저장을 중단합니다.
  * 팀스페이스 정보를 확인할 수 없을 때 사용자에게 안내 메시지를 표시합니다.
  * 단계 네비게이션 이동 시 비정상 인덱스 상황을 방지해 안정성을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->