### PR TITLE
CodeRabbit 리뷰 기반 안정성 이슈 수정

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -42,7 +42,7 @@ knowledge_base:
   code_guidelines:
     enabled: true
     filePatterns:
-      - docs/FRONTEND_CONVENTION.md
+      - src/docs/FRONTEND_CONVENTION.md
   learnings:
     scope: local
   issues:

--- a/src/components/Chat/ChatRoom/ChatRoomCreationModal/ChatRoomCreationModalContent.tsx
+++ b/src/components/Chat/ChatRoom/ChatRoomCreationModal/ChatRoomCreationModalContent.tsx
@@ -36,9 +36,11 @@ const ChatRoomCreationModalContent = ({
 	};
 
 	const checkTeamSpaceName = () => {
-		if (teamspaceName.length === 0) setNameError(CHAT_ROOM_CREATION_NAME_RULES.EMPTY);
-		else if (teamspaceName.length < 2) setNameError(CHAT_ROOM_CREATION_NAME_RULES.TOO_SHORT);
-		else if (teamspaceName.length > 15) setNameError(CHAT_ROOM_CREATION_NAME_RULES.TOO_LONG);
+		const trimmedTeamspaceName = teamspaceName.trim();
+
+		if (trimmedTeamspaceName.length === 0) setNameError(CHAT_ROOM_CREATION_NAME_RULES.EMPTY);
+		else if (trimmedTeamspaceName.length < 2) setNameError(CHAT_ROOM_CREATION_NAME_RULES.TOO_SHORT);
+		else if (trimmedTeamspaceName.length > 15) setNameError(CHAT_ROOM_CREATION_NAME_RULES.TOO_LONG);
 		else {
 			setNameError('');
 			return true;
@@ -49,7 +51,7 @@ const ChatRoomCreationModalContent = ({
 
 	const handlCreateClick = () => {
 		if (!checkTeamSpaceName()) return;
-		mutateCreateChatChannel(userStatus!.profile.lastSeenTeamspaceId, teamspaceName);
+		mutateCreateChatChannel(userStatus!.profile.lastSeenTeamspaceId, teamspaceName.trim());
 
 		setIsChatRoomModalOpen(false);
 	};

--- a/src/components/Chat/ChatRoom/ChatRoomCreationModal/ChatRoomCreationModalContent.tsx
+++ b/src/components/Chat/ChatRoom/ChatRoomCreationModal/ChatRoomCreationModalContent.tsx
@@ -5,7 +5,7 @@ import Heading from '@components/common/Heading/Heading';
 import Input from '@components/common/Input/Input';
 import Text from '@components/common/Text/Text';
 import useCreateChatChannelMutation from '@hooks/queries/chat/useCreateChatChannelMutation';
-import useUserStatusQuery from '@hooks/queries/useUserStatusQuery';
+import { useLastSeenTeamspaceId } from '@hooks/user/useLastSeenTeamspaceId';
 import * as S from './ChatRoomCreationModalContent.styled';
 
 interface ChatRoomCreationModalContentProps {
@@ -23,7 +23,7 @@ const ChatRoomCreationModalContent = ({
 }: ChatRoomCreationModalContentProps) => {
 	const [teamspaceName, setTeamspaceName] = useState('');
 	const [nameError, setNameError] = useState('');
-	const { userStatus } = useUserStatusQuery();
+	const lastSeenTeamspaceId = useLastSeenTeamspaceId();
 	const { mutateCreateChatChannel } = useCreateChatChannelMutation();
 
 	const handleNameChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -51,7 +51,9 @@ const ChatRoomCreationModalContent = ({
 
 	const handlCreateClick = () => {
 		if (!checkTeamSpaceName()) return;
-		mutateCreateChatChannel(userStatus!.profile.lastSeenTeamspaceId, teamspaceName.trim());
+		if (!lastSeenTeamspaceId) return;
+
+		mutateCreateChatChannel(lastSeenTeamspaceId, teamspaceName.trim());
 
 		setIsChatRoomModalOpen(false);
 	};

--- a/src/components/Chat/ChatRoom/ChatRoomCreationModal/ChatRoomCreationModalContent.tsx
+++ b/src/components/Chat/ChatRoom/ChatRoomCreationModal/ChatRoomCreationModalContent.tsx
@@ -21,26 +21,26 @@ const CHAT_ROOM_CREATION_NAME_RULES = {
 const ChatRoomCreationModalContent = ({
 	setIsChatRoomModalOpen,
 }: ChatRoomCreationModalContentProps) => {
-	const [teamspaceName, setTeamspaceName] = useState('');
+	const [chatRoomName, setChatRoomName] = useState('');
 	const [nameError, setNameError] = useState('');
 	const lastSeenTeamspaceId = useLastSeenTeamspaceId();
 	const { mutateCreateChatChannel } = useCreateChatChannelMutation();
 
 	const handleNameChange = (e: ChangeEvent<HTMLInputElement>) => {
 		const { value } = e.target;
-		setTeamspaceName(value);
+		setChatRoomName(value);
 	};
 
-	const handleCancleClick = () => {
+	const handleCancelClick = () => {
 		setIsChatRoomModalOpen(false);
 	};
 
-	const checkTeamSpaceName = () => {
-		const trimmedTeamspaceName = teamspaceName.trim();
+	const checkChatRoomName = () => {
+		const trimmedChatRoomName = chatRoomName.trim();
 
-		if (trimmedTeamspaceName.length === 0) setNameError(CHAT_ROOM_CREATION_NAME_RULES.EMPTY);
-		else if (trimmedTeamspaceName.length < 2) setNameError(CHAT_ROOM_CREATION_NAME_RULES.TOO_SHORT);
-		else if (trimmedTeamspaceName.length > 15) setNameError(CHAT_ROOM_CREATION_NAME_RULES.TOO_LONG);
+		if (trimmedChatRoomName.length === 0) setNameError(CHAT_ROOM_CREATION_NAME_RULES.EMPTY);
+		else if (trimmedChatRoomName.length < 2) setNameError(CHAT_ROOM_CREATION_NAME_RULES.TOO_SHORT);
+		else if (trimmedChatRoomName.length > 15) setNameError(CHAT_ROOM_CREATION_NAME_RULES.TOO_LONG);
 		else {
 			setNameError('');
 			return true;
@@ -49,11 +49,11 @@ const ChatRoomCreationModalContent = ({
 		return false;
 	};
 
-	const handlCreateClick = () => {
-		if (!checkTeamSpaceName()) return;
+	const handleCreateClick = () => {
+		if (!checkChatRoomName()) return;
 		if (!lastSeenTeamspaceId) return;
 
-		mutateCreateChatChannel(lastSeenTeamspaceId, teamspaceName.trim());
+		mutateCreateChatChannel(lastSeenTeamspaceId, chatRoomName.trim());
 
 		setIsChatRoomModalOpen(false);
 	};
@@ -69,9 +69,9 @@ const ChatRoomCreationModalContent = ({
 					placeholder='채팅방 이름을 입력하세요'
 					isError={!!nameError}
 					maxLength={15}
-					value={teamspaceName}
+					value={chatRoomName}
 					onChange={handleNameChange}
-					onEnterPress={handlCreateClick}
+					onEnterPress={handleCreateClick}
 				/>
 				<Flex height='14' align='center'>
 					{nameError && (
@@ -83,10 +83,10 @@ const ChatRoomCreationModalContent = ({
 			</Flex>
 			<Flex gap='6' justify='right' marginRight='20'>
 				<Flex width='60'>
-					<Button label='취소' variant='secondary' size='sm' isFull onClick={handleCancleClick} />
+					<Button label='취소' variant='secondary' size='sm' isFull onClick={handleCancelClick} />
 				</Flex>
 				<Flex width='60'>
-					<Button label='만들기' variant='primary' size='sm' isFull onClick={handlCreateClick} />
+					<Button label='만들기' variant='primary' size='sm' isFull onClick={handleCreateClick} />
 				</Flex>
 			</Flex>
 		</S.ChatRoomCreationModalContentContainer>

--- a/src/components/Setting/RoleAddModal/RoleAddModalContent.tsx
+++ b/src/components/Setting/RoleAddModal/RoleAddModalContent.tsx
@@ -5,7 +5,7 @@ import Heading from '@components/common/Heading/Heading';
 import Input from '@components/common/Input/Input';
 import Text from '@components/common/Text/Text';
 import useTeamSpaceRoleMutation from '@hooks/queries/teamspace/useTeamSpaceRoleMutation';
-import useUserStatusQuery from '@hooks/queries/useUserStatusQuery';
+import { useLastSeenTeamspaceId } from '@hooks/user/useLastSeenTeamspaceId';
 import * as S from './RoleAddModalContent.styled';
 
 interface RoleAddModalContentProps {
@@ -20,7 +20,7 @@ const ROLE_ADD_NAME_RULES = {
 const RoleAddModalContent = ({ setIsRoleAddModalOpen }: RoleAddModalContentProps) => {
 	const [roleName, setRoleName] = useState('');
 	const [nameError, setNameError] = useState('');
-	const { userStatus } = useUserStatusQuery();
+	const lastSeenTeamspaceId = useLastSeenTeamspaceId();
 	const { mutateAddTeamSpaceRole: mutateCreateRole } = useTeamSpaceRoleMutation();
 
 	const handleRoleNameChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -45,8 +45,9 @@ const RoleAddModalContent = ({ setIsRoleAddModalOpen }: RoleAddModalContentProps
 
 	const handleAddClick = () => {
 		if (!checkRoleName()) return;
+		if (!lastSeenTeamspaceId) return;
 
-		mutateCreateRole(userStatus!.profile.lastSeenTeamspaceId, roleName);
+		mutateCreateRole(lastSeenTeamspaceId, roleName.trim());
 		setIsRoleAddModalOpen(false);
 	};
 

--- a/src/components/common/GNB/GNBMenu/GNBProfile/GNBProfile.tsx
+++ b/src/components/common/GNB/GNBMenu/GNBProfile/GNBProfile.tsx
@@ -16,7 +16,7 @@ const GNBProfile = () => {
 	const handleLogOut = () => {
 		localStorage.removeItem(ACCESS_TOKEN);
 		navigate(PATH.SIGNIN);
-		queryClient.invalidateQueries({ queryKey: ['userStatus'] });
+		queryClient.removeQueries({ queryKey: ['userStatus'] });
 	};
 
 	return (
@@ -42,20 +42,10 @@ const GNBProfile = () => {
 							selected={false}
 							onClick={() => navigate(PATH.MYPAGE)}
 						/>
-						<MenuItem
-							leadingIcon='Mail'
-							title='문의하기'
-							selected={false}
-							onClick={() => ''}
-						/>
+						<MenuItem leadingIcon='Mail' title='문의하기' selected={false} onClick={() => ''} />
 					</Flex>
 					<Divider size='sm' padding={4} />
-					<MenuItem
-						leadingIcon='LogOut'
-						title='로그아웃'
-						selected={false}
-						onClick={handleLogOut}
-					/>
+					<MenuItem leadingIcon='LogOut' title='로그아웃' selected={false} onClick={handleLogOut} />
 				</>
 			)}
 		</S.GNBProfileContainer>

--- a/src/hooks/document/useDocumentDownload.ts
+++ b/src/hooks/document/useDocumentDownload.ts
@@ -10,7 +10,11 @@ const useDocumentDownload = ({
 	onAfterDownload,
 }: UseDocumentDownloadParams) => {
 	const handleDownloadClick = () => {
-		Array.from(selectedDocument).forEach((fileUrl, index) => {
+		const selectedFileUrls = Array.from(selectedDocument);
+
+		if (selectedFileUrls.length === 0) return;
+
+		selectedFileUrls.forEach((fileUrl, index) => {
 			window.setTimeout(() => {
 				const link = document.createElement('a');
 
@@ -20,10 +24,10 @@ const useDocumentDownload = ({
 				document.body.appendChild(link);
 				link.click();
 				document.body.removeChild(link);
+
+				if (index === selectedFileUrls.length - 1) onAfterDownload();
 			}, index * downloadIntervalMs);
 		});
-
-		onAfterDownload();
 	};
 
 	return { handleDownloadClick };

--- a/src/pages/SettingPage/SettingPage.tsx
+++ b/src/pages/SettingPage/SettingPage.tsx
@@ -246,7 +246,7 @@ const SettingPage = () => {
 									</Text>
 								</Flex>
 								<Button
-									label='역할 추가히기'
+									label='역할 추가하기'
 									variant='secondary'
 									size='sm'
 									leadingIcon='Plus'

--- a/src/pages/SettingPage/SettingPage.tsx
+++ b/src/pages/SettingPage/SettingPage.tsx
@@ -13,7 +13,7 @@ import useFileUpload from '@hooks/common/useFileUpload';
 import useDeleteTeamProfileMutation from '@hooks/queries/setting/useDeleteTeamProfileMutation';
 import useSettingMutation from '@hooks/queries/setting/useSettingMutation';
 import useTeamSettingQuery from '@hooks/queries/setting/useTeamSettingQuery';
-import useUserStatusQuery from '@hooks/queries/useUserStatusQuery';
+import { useLastSeenTeamspaceId } from '@hooks/user/useLastSeenTeamspaceId';
 import { TeamState, TeamSettingResult } from '@type/team';
 import useToastStore from '@stores/toastStore';
 import * as S from './SettingPage.styled';
@@ -28,8 +28,8 @@ const SettingPage = () => {
 	const [isRoleAddModalOpen, setIsRoleAddModalOpen] = useState(false);
 	const inputRef = useRef<HTMLInputElement | null>(null);
 	const { makeToast } = useToastStore();
-	const { userStatus } = useUserStatusQuery();
-	const { teamSetting } = useTeamSettingQuery(userStatus?.profile.lastSeenTeamspaceId);
+	const lastSeenTeamspaceId = useLastSeenTeamspaceId();
+	const { teamSetting } = useTeamSettingQuery(lastSeenTeamspaceId);
 	const { mutateSetting } = useSettingMutation();
 	const { uploadFiles, isFileSizeExceedLimit } = useFileUpload();
 	const { mutateDeleteTeamProfile } = useDeleteTeamProfileMutation();
@@ -148,17 +148,20 @@ const SettingPage = () => {
 
 	const handlSaveClick = async () => {
 		if (!checkTeamName()) return;
+		if (!lastSeenTeamspaceId) return;
+
 		const result = checkTeamSetting();
 		const files = inputRef.current?.files;
 
 		if (Object.keys(result).length !== 0) {
-			if (!teamInfo.profileImageUrl && teamSetting?.profileImageUrl)
-				await mutateDeleteTeamProfile(userStatus!.profile.lastSeenTeamspaceId);
-			else if (files && teamInfo.profileImageUrl !== teamSetting?.profileImageUrl) {
-				const url = await uploadFiles(files, 'TEAMSPACE', userStatus?.profile.lastSeenTeamspaceId);
+			if (!teamInfo.profileImageUrl && teamSetting?.profileImageUrl) {
+				await mutateDeleteTeamProfile(lastSeenTeamspaceId);
+			} else if (files && teamInfo.profileImageUrl !== teamSetting?.profileImageUrl) {
+				const url = await uploadFiles(files, 'TEAMSPACE', lastSeenTeamspaceId);
+
 				if (url) [result.profileImageUrl] = url;
 			}
-			mutateSetting(userStatus!.profile.lastSeenTeamspaceId, result);
+			mutateSetting(lastSeenTeamspaceId, result);
 		}
 	};
 

--- a/src/pages/SettingPage/SettingPage.tsx
+++ b/src/pages/SettingPage/SettingPage.tsx
@@ -102,8 +102,10 @@ const SettingPage = () => {
 	};
 
 	const checkTeamName = () => {
-		if (teamInfo.name.length === 0) setError('팀스페이스 이름은 공백일 수 없습니다.');
-		else if (teamInfo.name.length < 2) setError('팀스페이스 이름은 2글자 이상입니다.');
+		const trimmedTeamName = teamInfo.name.trim();
+
+		if (trimmedTeamName.length === 0) setError('팀스페이스 이름은 공백일 수 없습니다.');
+		else if (trimmedTeamName.length < 2) setError('팀스페이스 이름은 2글자 이상입니다.');
 		else {
 			setError('');
 			return true;
@@ -113,10 +115,12 @@ const SettingPage = () => {
 
 	const checkTeamSetting = () => {
 		const settingResult: TeamSettingResult = {};
+		const trimmedTeamName = teamInfo.name.trim();
+
 		if (teamInfo.profileImageUrl !== teamSetting?.profileImageUrl)
 			settingResult.profileImageUrl = teamInfo.profileImageUrl!;
 
-		if (teamInfo.name !== teamSetting?.name) settingResult.name = teamInfo.name;
+		if (trimmedTeamName !== teamSetting?.name) settingResult.name = trimmedTeamName;
 
 		teamInfo.users.forEach((teamUser, index) => {
 			if (teamSetting?.users[index]?.tag === null) {


### PR DESCRIPTION
﻿## 📌 관련 이슈

- closed: https://github.com/98OO/colla-frontend/issues/216

## ✨ PR 세부 내용

main 브랜치 병합 PR #215에 작성된 CodeRabbit 리뷰 중 실제 런타임 오류, 검증 누락, 설정 오류로 이어질 수 있는 항목을 수정했습니다.

**CodeRabbit 컨벤션 문서 경로 수정**
- `.coderabbit.yaml`의 컨벤션 문서 경로가 실제 파일 위치와 달라 CodeRabbit이 가이드 문서를 읽지 못할 수 있었습니다.
- `docs/FRONTEND_CONVENTION.md`를 `src/docs/FRONTEND_CONVENTION.md`로 수정했습니다.

**이름 입력값 공백 검증 보정**
- 채팅방 이름과 팀스페이스 이름 검증에서 `trim()` 기준으로 길이를 확인하도록 수정했습니다.
- 공백만 입력한 값이 유효한 이름으로 처리되지 않도록 보정했습니다.
- 팀스페이스 이름 저장 시에도 trim된 값을 반영하도록 수정했습니다.

**팀스페이스 식별자 누락 방어**
- 채팅방 생성과 역할 추가에서 `userStatus!` non-null assertion에 의존하던 흐름을 제거했습니다.
- `useLastSeenTeamspaceId`를 사용해 마지막 접속 팀스페이스 ID를 가져오고, 값이 없으면 생성 요청을 실행하지 않도록 방어했습니다.
- 역할 추가 시 입력값도 trim된 이름으로 요청하도록 수정했습니다.

**문서 다운로드 후처리 시점 보정**
- 다중 문서 다운로드에서 `onAfterDownload()`가 다운로드 타이머 등록 직후 실행되던 문제를 수정했습니다.
- 마지막 다운로드 click 실행 이후 후처리가 실행되도록 변경했습니다.
- 선택된 문서가 없을 때는 다운로드 로직을 실행하지 않도록 가드했습니다.

**문구 수정**
- 설정 페이지의 `역할 추가히기` 버튼 문구를 `역할 추가하기`로 수정했습니다.

## ✅ 리뷰 요구사항

- 채팅방 이름과 팀스페이스 이름에 공백만 입력했을 때 검증이 정상 동작하는지 확인해주세요.
- 마지막 접속 팀스페이스 ID가 없을 때 채팅방 생성/역할 추가 요청이 실행되지 않는지 확인해주세요.
- 다중 문서 다운로드 후 선택 상태 초기화가 마지막 다운로드 실행 이후 동작하는지 확인해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 채팅방, 팀 이름, 역할 이름 입력 시 공백 처리 방식 개선
  * 공백만 입력된 경우를 더 명확하게 처리하도록 개선
  * 설정 페이지 "역할 추가하기" 버튼 라벨 오타 수정

* **기타**
  * 내부 설정 파일 경로 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
