### PR TITLE
채팅 이미지 미리보기 리팩토링

### DIFF
--- a/src/components/Chat/ChatImageMessage/ChatImageMessage.styled.ts
+++ b/src/components/Chat/ChatImageMessage/ChatImageMessage.styled.ts
@@ -1,0 +1,42 @@
+import styled from 'styled-components';
+
+type Orientation = 'landscape' | 'portrait' | 'square';
+
+const IMAGE_CARD_SIZE: Record<Orientation, { width: string; height: string }> = {
+	landscape: {
+		width: '260px',
+		height: '174px',
+	},
+	portrait: {
+		width: '260px',
+		height: '325px',
+	},
+	square: {
+		width: '260px',
+		height: '260px',
+	},
+};
+
+export const ImageLink = styled.a<{
+	$isLoaded: boolean;
+	$orientation: Orientation;
+}>`
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	position: relative;
+	overflow: hidden;
+
+	width: ${(props) => IMAGE_CARD_SIZE[props.$orientation].width};
+	height: ${(props) => IMAGE_CARD_SIZE[props.$orientation].height};
+`;
+
+export const PreviewImage = styled.img<{ $isLoaded: boolean }>`
+	display: block;
+	width: auto;
+	height: auto;
+	max-width: 100%;
+	max-height: 100%;
+	object-fit: contain;
+	opacity: ${(props) => (props.$isLoaded ? 1 : 0)};
+`;

--- a/src/components/Chat/ChatImageMessage/ChatImageMessage.styled.ts
+++ b/src/components/Chat/ChatImageMessage/ChatImageMessage.styled.ts
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
-
-type Orientation = 'landscape' | 'portrait' | 'square';
+import type { Orientation } from '@type/chat';
 
 const IMAGE_CARD_SIZE: Record<Orientation, { width: string; height: string }> = {
 	landscape: {
@@ -18,7 +17,6 @@ const IMAGE_CARD_SIZE: Record<Orientation, { width: string; height: string }> = 
 };
 
 export const ImageLink = styled.a<{
-	$isLoaded: boolean;
 	$orientation: Orientation;
 }>`
 	display: flex;

--- a/src/components/Chat/ChatImageMessage/ChatImageMessage.tsx
+++ b/src/components/Chat/ChatImageMessage/ChatImageMessage.tsx
@@ -13,7 +13,7 @@ const ChatImageMessage = ({ src, alt }: ChatImageMessageProps) => {
 	const [isLoaded, setIsLoaded] = useState(false);
 	const [orientation, setOrientation] = useState<Orientation>('portrait');
 
-	const updateImageMeta = (event: React.SyntheticEvent<HTMLImageElement>) => {
+	const handleImageLoad = (event: React.SyntheticEvent<HTMLImageElement>) => {
 		const { naturalWidth, naturalHeight } = event.currentTarget;
 
 		if (naturalWidth > naturalHeight) setOrientation('landscape');
@@ -43,7 +43,7 @@ const ChatImageMessage = ({ src, alt }: ChatImageMessageProps) => {
 				src={src}
 				alt={alt}
 				loading='lazy'
-				onLoad={updateImageMeta}
+				onLoad={handleImageLoad}
 				$isLoaded={isLoaded}
 			/>
 		</S.ImageLink>

--- a/src/components/Chat/ChatImageMessage/ChatImageMessage.tsx
+++ b/src/components/Chat/ChatImageMessage/ChatImageMessage.tsx
@@ -23,16 +23,20 @@ const ChatImageMessage = ({ src, alt }: ChatImageMessageProps) => {
 		setIsLoaded(true);
 	};
 
+	const handleImageClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+		if (event.ctrlKey || event.metaKey || event.shiftKey) return;
+
+		event.preventDefault();
+		openImagePreviewWindow({ src, alt });
+	};
+
 	return (
 		<S.ImageLink
 			href={src}
 			target='_blank'
 			rel='noopener noreferrer'
 			aria-label={`${alt} 이미지 새 탭에서 보기`}
-			onClick={(event) => {
-				event.preventDefault();
-				openImagePreviewWindow({ src, alt });
-			}}
+			onClick={handleImageClick}
 			$isLoaded={isLoaded}
 			$orientation={orientation}>
 			<S.PreviewImage

--- a/src/components/Chat/ChatImageMessage/ChatImageMessage.tsx
+++ b/src/components/Chat/ChatImageMessage/ChatImageMessage.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import { openImagePreviewWindow } from '@utils/openImagePreviewWindow';
+import * as S from './ChatImageMessage.styled';
+
+type Orientation = 'landscape' | 'portrait' | 'square';
+
+interface ChatImageMessageProps {
+	src: string;
+	alt: string;
+}
+
+const ChatImageMessage = ({ src, alt }: ChatImageMessageProps) => {
+	const [isLoaded, setIsLoaded] = useState(false);
+	const [orientation, setOrientation] = useState<Orientation>('portrait');
+
+	const updateImageMeta = (event: React.SyntheticEvent<HTMLImageElement>) => {
+		const { naturalWidth, naturalHeight } = event.currentTarget;
+
+		if (naturalWidth > naturalHeight) setOrientation('landscape');
+		else if (naturalWidth < naturalHeight) setOrientation('portrait');
+		else setOrientation('square');
+
+		setIsLoaded(true);
+	};
+
+	return (
+		<S.ImageLink
+			href={src}
+			target='_blank'
+			rel='noopener noreferrer'
+			aria-label={`${alt} 이미지 새 탭에서 보기`}
+			onClick={(event) => {
+				event.preventDefault();
+				openImagePreviewWindow({ src, alt });
+			}}
+			$isLoaded={isLoaded}
+			$orientation={orientation}>
+			<S.PreviewImage
+				src={src}
+				alt={alt}
+				loading='lazy'
+				onLoad={updateImageMeta}
+				$isLoaded={isLoaded}
+			/>
+		</S.ImageLink>
+	);
+};
+
+export default ChatImageMessage;

--- a/src/components/Chat/ChatImageMessage/ChatImageMessage.tsx
+++ b/src/components/Chat/ChatImageMessage/ChatImageMessage.tsx
@@ -1,8 +1,7 @@
 import { useState } from 'react';
 import { openImagePreviewWindow } from '@utils/openImagePreviewWindow';
+import type { Orientation } from '@type/chat';
 import * as S from './ChatImageMessage.styled';
-
-type Orientation = 'landscape' | 'portrait' | 'square';
 
 interface ChatImageMessageProps {
 	src: string;
@@ -26,8 +25,9 @@ const ChatImageMessage = ({ src, alt }: ChatImageMessageProps) => {
 	const handleImageClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
 		if (event.ctrlKey || event.metaKey || event.shiftKey) return;
 
-		event.preventDefault();
-		openImagePreviewWindow({ src, alt });
+		const isPreviewOpened = openImagePreviewWindow({ src, alt });
+
+		if (isPreviewOpened) event.preventDefault();
 	};
 
 	return (
@@ -37,7 +37,6 @@ const ChatImageMessage = ({ src, alt }: ChatImageMessageProps) => {
 			rel='noopener noreferrer'
 			aria-label={`${alt} 이미지 새 탭에서 보기`}
 			onClick={handleImageClick}
-			$isLoaded={isLoaded}
 			$orientation={orientation}>
 			<S.PreviewImage
 				src={src}

--- a/src/components/Chat/MyMessageBox/MyMessageBox.styled.ts
+++ b/src/components/Chat/MyMessageBox/MyMessageBox.styled.ts
@@ -17,8 +17,7 @@ export const MyMessageBoxWrapper = styled.div<{ state: boolean; type: string }>`
 		props.type === 'TEXT'
 			? `${theme.units.spacing.space10} ${theme.units.spacing.space14}`
 			: `${theme.units.spacing.space10} 0 0 0`};
-	background-color: ${(props) =>
-		props.type === 'TEXT' ? theme.color.bg.iPrimary : 'none'};
+	background-color: ${(props) => (props.type === 'TEXT' ? theme.color.bg.iPrimary : 'none')};
 	border-radius: ${(props) =>
 		props.state
 			? `${theme.units.radius.radius20} 0 ${theme.units.radius.radius20} ${theme.units.radius.radius20}`
@@ -47,11 +46,6 @@ export const TimeWrapper = styled.div`
 
 export const ImageWrapper = styled.div`
 	display: flex;
+	flex-wrap: wrap;
 	gap: ${theme.units.spacing.space10};
-
-	img {
-		width: 100%;
-		height: 100%;
-		object-fit: cover;
-	}
 `;

--- a/src/components/Chat/MyMessageBox/MyMessageBox.tsx
+++ b/src/components/Chat/MyMessageBox/MyMessageBox.tsx
@@ -1,7 +1,8 @@
+import ChatAttachments from '@components/Chat/ChatAttachment/ChatAttachments';
+import ChatImageMessage from '@components/Chat/ChatImageMessage/ChatImageMessage';
 import Flex from '@components/common/Flex/Flex';
 import Text from '@components/common/Text/Text';
 import type { Attachment } from '@type/chat';
-import ChatAttachments from '../ChatAttachment/ChatAttachments';
 import * as S from './MyMessageBox.styled';
 
 export interface MyMessageBoxProps {
@@ -33,15 +34,7 @@ const MyMessageBox = (props: MyMessageBoxProps) => {
 				)}
 				{type === 'IMAGE' && (
 					<S.ImageWrapper>
-						{file?.map((img) => (
-							<a
-								key={img.id}
-								href={img.url}
-								target='_blank'
-								rel='noopener noreferrer'>
-								<img src={img.url} alt={img.filename} />
-							</a>
-						))}
+						{file?.map((img) => <ChatImageMessage key={img.id} src={img.url} alt={img.filename} />)}
 					</S.ImageWrapper>
 				)}
 				{type === 'FILE' && (

--- a/src/components/Chat/OtherMessageBox/OtherMessageBox.styled.ts
+++ b/src/components/Chat/OtherMessageBox/OtherMessageBox.styled.ts
@@ -7,9 +7,7 @@ export const OtherMessageBoxContainer = styled.div<{
 	display: flex;
 	width: 100%;
 	padding-top: ${(props) =>
-		props.state
-			? `${theme.units.spacing.space16}`
-			: `${theme.units.spacing.space6}`};
+		props.state ? `${theme.units.spacing.space16}` : `${theme.units.spacing.space6}`};
 	gap: ${theme.units.spacing.space8};
 `;
 
@@ -25,8 +23,7 @@ export const OtherMessageBoxWrapper = styled.div<{
 		props.type === 'TEXT'
 			? `${theme.units.spacing.space10} ${theme.units.spacing.space14}`
 			: `${theme.units.spacing.space10} 0 0 0`};
-	background-color: ${(props) =>
-		props.type === 'TEXT' ? theme.color.bg.secondary : 'none'};
+	background-color: ${(props) => (props.type === 'TEXT' ? theme.color.bg.secondary : 'none')};
 	border-radius: ${(props) =>
 		props.state
 			? `0 ${theme.units.radius.radius20} ${theme.units.radius.radius20} ${theme.units.radius.radius20}`
@@ -62,11 +59,6 @@ export const AvatarSpacer = styled.div`
 
 export const ImageWrapper = styled.div`
 	display: flex;
+	flex-wrap: wrap;
 	gap: ${theme.units.spacing.space10};
-
-	img {
-		width: 100%;
-		height: 100%;
-		object-fit: cover;
-	}
 `;

--- a/src/components/Chat/OtherMessageBox/OtherMessageBox.tsx
+++ b/src/components/Chat/OtherMessageBox/OtherMessageBox.tsx
@@ -1,8 +1,9 @@
+import ChatAttachments from '@components/Chat/ChatAttachment/ChatAttachments';
+import ChatImageMessage from '@components/Chat/ChatImageMessage/ChatImageMessage';
 import Avatar from '@components/common/Avatar/Avatar';
 import Flex from '@components/common/Flex/Flex';
 import Text from '@components/common/Text/Text';
 import type { Attachment } from '@type/chat';
-import ChatAttachments from '../ChatAttachment/ChatAttachments';
 import * as S from './OtherMessageBox.styled';
 
 export interface OtherMessageBoxProps {
@@ -43,13 +44,7 @@ const OtherMessageBox = (props: OtherMessageBoxProps) => {
 						{type === 'IMAGE' && (
 							<S.ImageWrapper>
 								{file?.map((img) => (
-									<a
-										key={img.id}
-										href={img.url}
-										target='_blank'
-										rel='noopener noreferrer'>
-										<img src={img.url} alt={img.filename} />
-									</a>
+									<ChatImageMessage key={img.id} src={img.url} alt={img.filename} />
 								))}
 							</S.ImageWrapper>
 						)}

--- a/src/hooks/chatting/useChatMessages.ts
+++ b/src/hooks/chatting/useChatMessages.ts
@@ -28,10 +28,10 @@ const useChatMessages = (props: useChatMessagesProps) => {
 		const latestMessages = messagePages[0]?.chatChannelMessages ?? [];
 		const latestMessageId = latestMessages[0]?.id;
 
-		if (!latestMessageId || !userStatus) return;
+		if (!latestMessageId || !userStatus || !stompClient) return;
 		if (lastReadMessageIdRef.current === latestMessageId) return;
 
-		stompClient?.send(
+		stompClient.send(
 			END_POINTS.READ_MESSAGE(userStatus.profile.lastSeenTeamspaceId, selectedChat, latestMessageId)
 		);
 		lastReadMessageIdRef.current = latestMessageId;

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -38,3 +38,5 @@ export interface Message {
 export interface ChatData {
 	chatChannelMessages: Message[];
 }
+
+export type Orientation = 'landscape' | 'portrait' | 'square';

--- a/src/utils/openImagePreviewWindow.ts
+++ b/src/utils/openImagePreviewWindow.ts
@@ -1,0 +1,29 @@
+interface OpenImagePreviewWindowParams {
+	src: string;
+	alt: string;
+}
+
+export const openImagePreviewWindow = ({ src, alt }: OpenImagePreviewWindowParams) => {
+	const imageWindow = window.open('', '_blank');
+
+	if (!imageWindow) return;
+
+	imageWindow.opener = null;
+	imageWindow.document.title = alt;
+	imageWindow.document.body.style.margin = '0';
+	imageWindow.document.body.style.backgroundColor = '#0f1115';
+	imageWindow.document.body.style.display = 'flex';
+	imageWindow.document.body.style.alignItems = 'center';
+	imageWindow.document.body.style.justifyContent = 'center';
+	imageWindow.document.body.style.minHeight = '100vh';
+
+	const previewImage = imageWindow.document.createElement('img');
+
+	previewImage.src = src;
+	previewImage.alt = alt;
+	previewImage.style.maxWidth = '100vw';
+	previewImage.style.maxHeight = '100vh';
+	previewImage.style.objectFit = 'contain';
+
+	imageWindow.document.body.replaceChildren(previewImage);
+};

--- a/src/utils/openImagePreviewWindow.ts
+++ b/src/utils/openImagePreviewWindow.ts
@@ -6,7 +6,7 @@ interface OpenImagePreviewWindowParams {
 export const openImagePreviewWindow = ({ src, alt }: OpenImagePreviewWindowParams) => {
 	const imageWindow = window.open('', '_blank');
 
-	if (!imageWindow) return;
+	if (!imageWindow) return false;
 
 	imageWindow.opener = null;
 	imageWindow.document.title = alt;
@@ -26,4 +26,6 @@ export const openImagePreviewWindow = ({ src, alt }: OpenImagePreviewWindowParam
 	previewImage.style.objectFit = 'contain';
 
 	imageWindow.document.body.replaceChildren(previewImage);
+
+	return true;
 };


### PR DESCRIPTION
﻿## 📌 관련 이슈

- #219

## ✨ PR 세부 내용

채팅 메시지의 이미지 표시와 미리보기 동작을 별도 컴포넌트와 유틸로 분리했습니다.  
기존에는 이미지가 단순 `<img>` 링크로만 렌더링되어 있었기 때문에, 이미지 크기와 미리보기 동작을 메시지 타입별로 일관되게 제어하기 어려웠습니다. 이번 작업에서는 채팅 이미지 표시 책임을 분리하고, 클릭 시 새 창 미리보기를 통일된 방식으로 처리하도록 정리했습니다.

**핵심 변경**
- 이미지 미리보기용 `openImagePreviewWindow` 유틸 추가
- 채팅 이미지 표시용 `ChatImageMessage` 컴포넌트 추가
- 이미지 비율에 따라 표시 크기를 다르게 적용하도록 정리
- 이미지 로드 완료 전/후 표시 상태를 분리
- `MyMessageBox` / `OtherMessageBox`에서 이미지 렌더링 로직 교체

**구조 개선**
- 이미지 미리보기 동작을 메시지 박스에서 분리해 재사용 가능한 유틸로 정리
- 이미지 렌더링을 텍스트/파일 렌더링과 분리해 메시지 타입별 책임을 분리
- 가로/세로/정방형 이미지에 대해 고정된 크기 규칙을 적용하도록 개선

**효과**
- 채팅 이미지 표시와 미리보기 동작이 한곳에 모여 유지보수가 쉬워짐
- 메시지 박스 내부의 조건 분기가 줄어들어 구조가 단순해짐
- 이미지 비율에 따른 표시 흔들림을 줄이고 미리보기 동작을 통일할 수 있음

## 📸 스크린샷
<img width="1920" height="1020" alt="채팅 이미지" src="https://github.com/user-attachments/assets/839e6ea4-5058-43b4-9f26-04b7862afaa7" />

## ✅ 리뷰 요구사항

- 이미지 메시지를 클릭했을 때 새 창 미리보기가 정상적으로 열리는지 확인해주세요.
- 가로/세로/정방형 이미지가 각각 의도한 크기로 표시되는지 확인해주세요.
- 텍스트 메시지와 파일 메시지 렌더링이 기존 동작과 다르지 않은지 확인해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * 채팅의 이미지 메시지 표시가 개선되어 비율(가로/세로/정사각)에 맞게 카드 크기가 조정됩니다.
  * 이미지를 클릭하면 새 탭에서 미리보기가 열리며, 로드가 완료된 뒤에만 표시됩니다.
* **Bug Fixes**
  * 읽음 처리 전송은 연결 상태가 없을 때 즉시 중단되어 불필요한 동작을 줄였습니다.
* **Improvements**
  * 이미지가 여러 장일 때 줄바꿈과 간격 레이아웃이 더 안정적으로 적용됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->