### PR TITLE
에러·로딩 상태 처리 구조 개선

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
+import AsyncBoundary from '@components/common/AsyncBoundary/AsyncBoundary';
 import Flex from '@components/common/Flex/Flex';
 import GlobalErrorBoundary from '@components/common/GlobalErrorBoundary/GlobalErrorBoundary';
 import GNB from '@components/common/GNB/GNB';
@@ -33,9 +34,7 @@ function App() {
 	const onConnected = () => {
 		if (localStorage.getItem(ACCESS_TOKEN)) {
 			const client = Stomp.over(function () {
-				return new SockJS(
-					`${WEBSOCKET_URL}${localStorage.getItem(ACCESS_TOKEN)}`
-				);
+				return new SockJS(`${WEBSOCKET_URL}${localStorage.getItem(ACCESS_TOKEN)}`);
 			});
 
 			client.connect({}, () => {
@@ -55,10 +54,11 @@ function App() {
 			<Flex direction='column'>
 				{isNavigationBarVisible && <GNB />}
 				<Flex>
-					{isNavigationBarVisible &&
-						(isMobileView || isChatPage ? <SNBIcon /> : <SNBFull />)}
+					{isNavigationBarVisible && (isMobileView || isChatPage ? <SNBIcon /> : <SNBFull />)}
 					<main>
-						<Outlet />
+						<AsyncBoundary resetKeys={[location.pathname]}>
+							<Outlet />
+						</AsyncBoundary>
 					</main>
 				</Flex>
 			</Flex>

--- a/src/apis/NetworkError.ts
+++ b/src/apis/NetworkError.ts
@@ -1,0 +1,9 @@
+export class NetworkError extends Error {
+	constructor(message = '네트워크 연결을 확인할 수 없습니다.') {
+		super(message);
+
+		this.name = 'NetworkError';
+
+		Object.setPrototypeOf(this, NetworkError.prototype);
+	}
+}

--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -1,9 +1,5 @@
 import axios from 'axios';
-import {
-	setAuthorizedRequest,
-	handleTokenError,
-	handleAPIError,
-} from '@apis/axiosInterceptors';
+import { setAuthorizedRequest, handleTokenError, handleAPIError } from '@apis/axiosInterceptors';
 import { BASE_URL, NETWORK_TIMEOUT } from '@constants/api';
 
 export const axiosInstance = axios.create({
@@ -15,9 +11,6 @@ export const axiosInstance = axios.create({
 
 axiosInstance.interceptors.request.use(setAuthorizedRequest, handleAPIError);
 
-axiosInstance.interceptors.response.use(
-	(response) => response,
-	handleTokenError
-);
+axiosInstance.interceptors.response.use((response) => response, handleTokenError);
 
 axiosInstance.interceptors.response.use((response) => response, handleAPIError);

--- a/src/apis/axiosInterceptors.ts
+++ b/src/apis/axiosInterceptors.ts
@@ -33,7 +33,11 @@ export const setAuthorizedRequest = (config: InternalAxiosRequestConfig) => {
 export const handleTokenError = async (error: AxiosError<ErrorResponse>) => {
 	const originalRequest = error.config;
 
-	if (!error.response) throw new NetworkError();
+	if (!error.response) {
+		if (error.isAxiosError) throw new NetworkError();
+		throw error;
+	}
+
 	if (!originalRequest) throw error;
 
 	const { data, status } = error.response;

--- a/src/apis/axiosInterceptors.ts
+++ b/src/apis/axiosInterceptors.ts
@@ -2,11 +2,8 @@ import { getNewToken } from '@apis/user/getNewToken';
 import { queryClient } from '@hooks/queries/common/queryClient';
 import { axiosInstance } from '@apis/axiosInstance';
 import { HTTPError } from '@apis/HTTPError';
-import {
-	HTTP_STATUS_CODE,
-	AUTH_ERROR_CODE,
-	ACCESS_TOKEN,
-} from '@constants/api';
+import { NetworkError } from '@apis/NetworkError';
+import { HTTP_STATUS_CODE, AUTH_ERROR_CODE, ACCESS_TOKEN } from '@constants/api';
 import { PATH } from '@constants/path';
 import type { AxiosError, InternalAxiosRequestConfig } from 'axios';
 
@@ -18,8 +15,7 @@ export interface ErrorResponse {
 }
 
 export const setAuthorizedRequest = (config: InternalAxiosRequestConfig) => {
-	if (!config.authRequired || !config.headers || config.headers.Authorization)
-		return config;
+	if (!config.authRequired || !config.headers || config.headers.Authorization) return config;
 
 	const accessToken = localStorage.getItem(ACCESS_TOKEN);
 
@@ -37,10 +33,9 @@ export const setAuthorizedRequest = (config: InternalAxiosRequestConfig) => {
 export const handleTokenError = async (error: AxiosError<ErrorResponse>) => {
 	const originalRequest = error.config;
 
-	if (!error.response || !originalRequest)
-		throw new Error(
-			'네트워크 요청이 실패하였거나, 요청 객체를 찾을 수 없습니다.'
-		);
+	if (!error.response) throw new NetworkError();
+	if (!originalRequest) throw error;
+
 	const { data, status } = error.response;
 
 	if (
@@ -76,12 +71,14 @@ export const handleTokenError = async (error: AxiosError<ErrorResponse>) => {
 };
 
 export const handleAPIError = (error: AxiosError<ErrorResponse>) => {
-	if (!error.response) throw error;
+	if (error instanceof HTTPError || error instanceof NetworkError) throw error;
 
-	const { data, status } = error.response;
-	if (status >= HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR) {
-		throw new HTTPError(HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR);
+	if (!error.response) {
+		if (error.isAxiosError) throw new NetworkError();
+		throw error;
 	}
 
-	throw new HTTPError(status, data.code, data.content, data.message);
+	const { data, status } = error.response;
+
+	throw new HTTPError(status, data?.code, data?.content, data?.message);
 };

--- a/src/components/Feed/BaseFeed/BaseFeed.styled.ts
+++ b/src/components/Feed/BaseFeed/BaseFeed.styled.ts
@@ -1,10 +1,11 @@
 import { styled } from 'styled-components';
+import { FEED_CARD_WIDTH } from '@styles/layout';
 import theme from '@styles/theme';
 
 export const FeedContainer = styled.div`
 	display: flex;
 	flex-direction: column;
-	width: 680px;
+	width: ${FEED_CARD_WIDTH}px;
 	padding: ${theme.units.spacing.space24} 0 ${theme.units.spacing.space8} 0;
 	border-radius: ${theme.units.radius.radius12};
 	box-shadow: ${theme.elevation.shadow.shadow4};

--- a/src/components/Feed/FeedList/FeedList.tsx
+++ b/src/components/Feed/FeedList/FeedList.tsx
@@ -1,0 +1,49 @@
+import InfiniteScroll from 'react-infinite-scroller';
+import Feed from '@components/Feed/Feed';
+import useFeedsQuery from '@hooks/queries/Feed/useFeedsQuery';
+import { getSanitizedFeeds } from '@utils/getSanitizedFeeds';
+import type { FeedData, FeedType } from '@type/feed';
+
+interface FeedListProps {
+	teamspaceId: number;
+	type?: FeedType;
+	isDrawerOpen: (feedId: number) => boolean;
+	openDrawer: (feedId: number) => void;
+	closeDrawer: () => void;
+}
+
+const FeedList = ({ teamspaceId, type, isDrawerOpen, openDrawer, closeDrawer }: FeedListProps) => {
+	const { feeds, hasNextPage, isFetching, fetchNextPage } = useFeedsQuery({
+		teamspaceId,
+		type,
+	});
+
+	return (
+		<InfiniteScroll
+			loadMore={() => {
+				if (!isFetching) fetchNextPage();
+			}}
+			hasMore={hasNextPage}
+			useWindow={false}>
+			{feeds.pages.map((pageData) => {
+				const sanitizedFeeds = getSanitizedFeeds(pageData.content.feeds);
+
+				return sanitizedFeeds.map((feedData: FeedData) => {
+					const { feedId } = feedData;
+
+					return (
+						<Feed
+							key={feedId}
+							feedData={feedData}
+							isDetailOpen={isDrawerOpen(feedId)}
+							openDetail={() => openDrawer(feedId)}
+							closeDetail={closeDrawer}
+						/>
+					);
+				});
+			})}
+		</InfiniteScroll>
+	);
+};
+
+export default FeedList;

--- a/src/components/Feed/FeedSkeletonList/FeedSkeletonList.styled.ts
+++ b/src/components/Feed/FeedSkeletonList/FeedSkeletonList.styled.ts
@@ -1,0 +1,46 @@
+import styled from 'styled-components';
+import { FEED_BODY_MIN_HEIGHT, FEED_CARD_WIDTH } from '@styles/layout';
+import theme from '@styles/theme';
+
+export const FeedSkeletonList = styled.div`
+	display: flex;
+	flex-direction: column;
+`;
+
+export const FeedSkeleton = styled.div`
+	display: flex;
+	flex-direction: column;
+	width: ${FEED_CARD_WIDTH}px;
+	padding: ${theme.units.spacing.space24} 0 ${theme.units.spacing.space8} 0;
+	border-radius: ${theme.units.radius.radius12};
+	box-shadow: ${theme.elevation.shadow.shadow4};
+	margin-bottom: ${theme.units.spacing.space32};
+`;
+
+export const FeedSkeletonContent = styled.div`
+	display: flex;
+	flex-direction: column;
+	padding: 0 ${theme.units.spacing.space24};
+	gap: ${theme.units.spacing.space24};
+`;
+
+export const FeedSkeletonBody = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: ${theme.units.spacing.space12};
+	padding: ${theme.units.spacing.space16} 0;
+	min-height: ${FEED_BODY_MIN_HEIGHT}px;
+`;
+
+export const FeedSkeletonDivider = styled.div`
+	display: flex;
+	padding: ${theme.units.spacing.space16} ${theme.units.spacing.space24};
+`;
+
+export const FeedSkeletonFooter = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: ${theme.units.spacing.space12};
+	margin: 0 ${theme.units.spacing.space24} ${theme.units.spacing.space6}
+		${theme.units.spacing.space24};
+`;

--- a/src/components/Feed/FeedSkeletonList/FeedSkeletonList.tsx
+++ b/src/components/Feed/FeedSkeletonList/FeedSkeletonList.tsx
@@ -1,0 +1,45 @@
+import Flex from '@components/common/Flex/Flex';
+import Skeleton from '@components/common/Skeleton/Skeleton';
+import * as S from './FeedSkeletonList.styled';
+
+const FeedSkeleton = () => (
+	<S.FeedSkeleton>
+		<S.FeedSkeletonContent>
+			<Flex gap='8' align='center'>
+				<Skeleton width={40} height={40} radius='50%' />
+				<Flex direction='column' gap='8'>
+					<Skeleton width={120} height={16} />
+					<Skeleton width={80} height={12} />
+				</Flex>
+			</Flex>
+			<Flex direction='column' gap='12'>
+				<Skeleton width='40%' height={20} />
+				<S.FeedSkeletonBody>
+					<Skeleton width='100%' height={16} />
+					<Skeleton width='95%' height={16} />
+					<Skeleton width='98%' height={16} />
+					<Skeleton width='60%' height={16} />
+				</S.FeedSkeletonBody>
+			</Flex>
+		</S.FeedSkeletonContent>
+		<S.FeedSkeletonDivider />
+		<S.FeedSkeletonFooter>
+			<Skeleton width={56} height={24} />
+			<Skeleton width='70%' height={16} />
+		</S.FeedSkeletonFooter>
+	</S.FeedSkeleton>
+);
+
+interface FeedSkeletonListProps {
+	count?: number;
+}
+
+const FeedSkeletonList = ({ count = 2 }: FeedSkeletonListProps) => (
+	<S.FeedSkeletonList role='status' aria-label='피드를 불러오는 중'>
+		{Array.from({ length: count }, (_, index) => (
+			<FeedSkeleton key={index} />
+		))}
+	</S.FeedSkeletonList>
+);
+
+export default FeedSkeletonList;

--- a/src/components/Feed/NormalFeed/NormalFeed.styled.ts
+++ b/src/components/Feed/NormalFeed/NormalFeed.styled.ts
@@ -1,12 +1,12 @@
 import { styled } from 'styled-components';
 import { editorStyles } from '@styles/editorStyles';
-import { FEED_DETAIL_MAX_HEIGHT } from '@styles/layout';
+import { FEED_BODY_MIN_HEIGHT, FEED_CARD_WIDTH, FEED_DETAIL_MAX_HEIGHT } from '@styles/layout';
 import theme from '@styles/theme';
 
 export const FeedContainer = styled.div`
 	display: flex;
 	flex-direction: column;
-	width: 680px;
+	width: ${FEED_CARD_WIDTH}px;
 	padding: ${theme.units.spacing.space24} 0 ${theme.units.spacing.space8} 0;
 	border-radius: ${theme.units.radius.radius12};
 	box-shadow: ${theme.elevation.shadow.shadow4};
@@ -16,7 +16,7 @@ export const FeedContainer = styled.div`
 export const DetailWrapper = styled.div<{ hasMoreButton: boolean }>`
 	${editorStyles}
 	padding: ${theme.units.spacing.space16} 0;
-	min-height: 150px;
+	min-height: ${FEED_BODY_MIN_HEIGHT}px;
 	max-height: ${FEED_DETAIL_MAX_HEIGHT}px;
 	position: relative;
 	overflow: hidden;

--- a/src/components/Post/SchedulingPost/SchedulingPost.tsx
+++ b/src/components/Post/SchedulingPost/SchedulingPost.tsx
@@ -11,7 +11,7 @@ const STEPS = ['selectDate', 'setCondition'] as const;
 const SchedulingPost = () => {
 	const { Funnel, step, goNext, goPrev } = useHistoryFunnel(STEPS);
 	const { formData, handleTargetDates, handleCondition } = useSchedulingPostForm();
-	const { mutateSchedulingPost } = useSchedulingPostMutation();
+	const { mutateSchedulingPost, isPending } = useSchedulingPostMutation();
 
 	const handleSubmit = (condition: SchedulingCondition) => {
 		mutateSchedulingPost({
@@ -36,6 +36,7 @@ const SchedulingPost = () => {
 						initialDueAtDate={formData.dueAtDate}
 						initialDueAtTime={formData.dueAtTime}
 						initialTimeRange={formData.timeRange}
+						isSubmitting={isPending}
 						onPrev={goPrev}
 						onSave={handleCondition}
 						onSubmit={handleSubmit}

--- a/src/components/Post/SchedulingPost/Step/SetConditionStep.tsx
+++ b/src/components/Post/SchedulingPost/Step/SetConditionStep.tsx
@@ -14,6 +14,7 @@ interface SetConditionProps {
 	initialDueAtDate: DateString;
 	initialDueAtTime: TimeString;
 	initialTimeRange: TimeRange;
+	isSubmitting?: boolean;
 	onPrev: () => void;
 	onSave: (condition: SchedulingCondition) => void;
 	onSubmit: (condition: SchedulingCondition) => void;
@@ -24,6 +25,7 @@ const SetConditionStep = ({
 	initialDueAtDate,
 	initialDueAtTime,
 	initialTimeRange,
+	isSubmitting = false,
 	onPrev,
 	onSave,
 	onSubmit,
@@ -84,7 +86,13 @@ const SetConditionStep = ({
 			</Flex>
 			<Flex justify='flex-end' gap='12'>
 				<Button label='이전' variant='secondary' size='md' onClick={handlePrev} />
-				<Button label='등록' variant='primary' size='md' onClick={handleSubmit} />
+				<Button
+					label='등록'
+					variant='primary'
+					size='md'
+					onClick={handleSubmit}
+					disabled={isSubmitting}
+				/>
 			</Flex>
 		</>
 	);

--- a/src/components/common/AsyncBoundary/AsyncBoundary.tsx
+++ b/src/components/common/AsyncBoundary/AsyncBoundary.tsx
@@ -1,0 +1,29 @@
+import { Suspense } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+import type { FallbackProps } from 'react-error-boundary';
+import { ErrorFallback } from '@components/common/ErrorFallback/ErrorFallback';
+import { useQueryErrorResetBoundary } from '@tanstack/react-query';
+
+interface AsyncBoundaryProps {
+	children: React.ReactNode;
+	loadingFallback?: React.ReactNode;
+	errorFallback?: React.ComponentType<FallbackProps>;
+	resetKeys?: unknown[];
+}
+
+const AsyncBoundary = ({
+	children,
+	loadingFallback = null,
+	errorFallback = ErrorFallback,
+	resetKeys,
+}: AsyncBoundaryProps) => {
+	const { reset } = useQueryErrorResetBoundary();
+
+	return (
+		<ErrorBoundary FallbackComponent={errorFallback} onReset={reset} resetKeys={resetKeys}>
+			<Suspense fallback={loadingFallback}>{children}</Suspense>
+		</ErrorBoundary>
+	);
+};
+
+export default AsyncBoundary;

--- a/src/components/common/Error/Error.tsx
+++ b/src/components/common/Error/Error.tsx
@@ -1,33 +1,17 @@
-import { useEffect } from 'react';
 import { Button } from '@components/common/Button/Button';
 import Flex from '@components/common/Flex/Flex';
 import Heading from '@components/common/Heading/Heading';
 import Text from '@components/common/Text/Text';
-import { HTTP_STATUS_CODE, HTTP_ERROR_MESSAGE } from '@constants/api';
+import type { ErrorMessage } from '@constants/api';
 import { signPost } from '@assets/png';
 import * as S from './Error.styled';
 
 interface ErrorProps {
-	errorCode: number;
+	errorMessage: ErrorMessage;
 	resetError: () => void;
 }
 
-const Error = ({ errorCode, resetError }: ErrorProps) => {
-	const errorMessage =
-		errorCode === HTTP_STATUS_CODE.NOT_FOUND || errorCode === HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR
-			? HTTP_ERROR_MESSAGE[errorCode]
-			: HTTP_ERROR_MESSAGE.DEFAULT;
-
-	useEffect(() => {
-		if (
-			errorCode === HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR ||
-			(errorCode !== HTTP_STATUS_CODE.NOT_FOUND &&
-				errorCode !== HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR)
-		) {
-			localStorage.removeItem('ACCESS_TOKEN');
-		}
-	}, [errorCode]);
-
+const Error = ({ errorMessage, resetError }: ErrorProps) => {
 	return (
 		<Flex gap='72' align='center'>
 			<S.ImageWrapper>
@@ -38,15 +22,11 @@ const Error = ({ errorCode, resetError }: ErrorProps) => {
 					{errorMessage.HEADING}
 				</Heading>
 				<Flex direction='column' gap='16'>
-					<Text size='lg' weight='medium' color='secondary'>
-						{errorMessage.BODY.firstLine}
-					</Text>
-					<Text size='lg' weight='medium' color='secondary'>
-						{errorMessage.BODY.secondLine}
-					</Text>
-					<Text size='lg' weight='medium' color='secondary'>
-						{errorMessage.BODY.thirdLine}
-					</Text>
+					{errorMessage.BODY.map((line) => (
+						<Text key={line} size='lg' weight='medium' color='secondary'>
+							{line}
+						</Text>
+					))}
 				</Flex>
 				<Button
 					label={errorMessage.BUTTON}

--- a/src/components/common/Error/Error.tsx
+++ b/src/components/common/Error/Error.tsx
@@ -14,8 +14,7 @@ interface ErrorProps {
 
 const Error = ({ errorCode, resetError }: ErrorProps) => {
 	const errorMessage =
-		errorCode === HTTP_STATUS_CODE.NOT_FOUND ||
-		errorCode === HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR
+		errorCode === HTTP_STATUS_CODE.NOT_FOUND || errorCode === HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR
 			? HTTP_ERROR_MESSAGE[errorCode]
 			: HTTP_ERROR_MESSAGE.DEFAULT;
 
@@ -46,7 +45,7 @@ const Error = ({ errorCode, resetError }: ErrorProps) => {
 						{errorMessage.BODY.secondLine}
 					</Text>
 					<Text size='lg' weight='medium' color='secondary'>
-						{errorMessage.BODY.thridLine}
+						{errorMessage.BODY.thirdLine}
 					</Text>
 				</Flex>
 				<Button

--- a/src/components/common/ErrorFallback/ErrorFallback.tsx
+++ b/src/components/common/ErrorFallback/ErrorFallback.tsx
@@ -1,21 +1,50 @@
 import { FallbackProps } from 'react-error-boundary';
 import { useNavigate } from 'react-router-dom';
 import Error from '@components/common/Error/Error';
-import { HTTP_STATUS_CODE } from '@constants/api';
+import { HTTPError } from '@apis/HTTPError';
+import { NetworkError } from '@apis/NetworkError';
+import { HTTP_ERROR_MESSAGE, HTTP_STATUS_CODE } from '@constants/api';
+import type { ErrorMessage } from '@constants/api';
 import { PATH } from '@constants/path';
+
+interface ErrorFallbackInfo {
+	message: ErrorMessage;
+	recovery: 'retry' | 'navigate';
+}
+
+const errorToFallbackInfo = (error: unknown): ErrorFallbackInfo => {
+	if (error instanceof NetworkError) {
+		return { message: HTTP_ERROR_MESSAGE.NETWORK, recovery: 'retry' };
+	}
+
+	if (error instanceof HTTPError) {
+		const { status } = error;
+
+		if (status === HTTP_STATUS_CODE.FORBIDDEN) {
+			return { message: HTTP_ERROR_MESSAGE[HTTP_STATUS_CODE.FORBIDDEN], recovery: 'navigate' };
+		}
+		if (status === HTTP_STATUS_CODE.NOT_FOUND) {
+			return { message: HTTP_ERROR_MESSAGE[HTTP_STATUS_CODE.NOT_FOUND], recovery: 'navigate' };
+		}
+		if (status >= HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR) {
+			return {
+				message: HTTP_ERROR_MESSAGE[HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR],
+				recovery: 'retry',
+			};
+		}
+	}
+
+	return { message: HTTP_ERROR_MESSAGE.DEFAULT, recovery: 'retry' };
+};
 
 export const ErrorFallback = ({ error, resetErrorBoundary }: FallbackProps) => {
 	const navigate = useNavigate();
-	const { status } = error;
+	const { message, recovery } = errorToFallbackInfo(error);
 
-	const handleServerError = () => {
+	const handleReset = () => {
 		resetErrorBoundary();
-		navigate(PATH.ROOT);
+		if (recovery === 'navigate') navigate(PATH.ROOT);
 	};
 
-	if (status === HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR) {
-		return <Error errorCode={status} resetError={handleServerError} />;
-	}
-
-	return <Error errorCode={status} resetError={resetErrorBoundary} />;
+	return <Error errorMessage={message} resetError={handleReset} />;
 };

--- a/src/components/common/Skeleton/Skeleton.styled.ts
+++ b/src/components/common/Skeleton/Skeleton.styled.ts
@@ -1,0 +1,33 @@
+import styled, { keyframes } from 'styled-components';
+import theme from '@styles/theme';
+
+interface SkeletonBoxProps {
+	$width?: number | string;
+	$height?: number | string;
+	$radius?: number | string;
+}
+
+const shimmer = keyframes`
+	0% {
+		background-position: 200% 0;
+	}
+	100% {
+		background-position: -200% 0;
+	}
+`;
+
+const toCssSize = (value: number | string) => (typeof value === 'number' ? `${value}px` : value);
+
+export const SkeletonBox = styled.div<SkeletonBoxProps>`
+	width: ${(props) => toCssSize(props.$width ?? '100%')};
+	height: ${(props) => toCssSize(props.$height ?? theme.units.spacing.space16)};
+	border-radius: ${(props) => toCssSize(props.$radius ?? theme.units.radius.radius4)};
+	background: linear-gradient(
+		90deg,
+		${theme.color.bg.secondary} 25%,
+		${theme.color.border.tertiary} 50%,
+		${theme.color.bg.secondary} 75%
+	);
+	background-size: 200% 100%;
+	animation: ${shimmer} 1.5s ease-in-out infinite;
+`;

--- a/src/components/common/Skeleton/Skeleton.tsx
+++ b/src/components/common/Skeleton/Skeleton.tsx
@@ -1,0 +1,13 @@
+import * as S from './Skeleton.styled';
+
+export interface SkeletonProps {
+	width?: number | string;
+	height?: number | string;
+	radius?: number | string;
+}
+
+const Skeleton = ({ width, height, radius }: SkeletonProps) => {
+	return <S.SkeletonBox $width={width} $height={height} $radius={radius} aria-hidden />;
+};
+
+export default Skeleton;

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -83,53 +83,55 @@ export const ACCESS_TOKEN = 'ACCESS_TOKEN';
 
 export const INVITE_URL = 'INVITE_URL';
 
+export interface ErrorMessage {
+	HEADING: string;
+	BODY: string[];
+	BUTTON: string;
+}
+
 export const HTTP_ERROR_MESSAGE = {
 	[HTTP_STATUS_CODE.FORBIDDEN]: {
 		HEADING: '접근 권한이 없어요',
-		BODY: {
-			firstLine: '이 페이지를 볼 수 있는 권한이 없습니다',
-			secondLine: '팀스페이스에서 나갔거나 권한이 변경되었을 수 있습니다',
-			thirdLine: '필요한 경우 팀스페이스 관리자에게 문의해주세요',
-		},
+		BODY: [
+			'이 페이지를 볼 수 있는 권한이 없습니다',
+			'팀스페이스에서 나갔거나 권한이 변경되었을 수 있습니다',
+			'필요한 경우 팀스페이스 관리자에게 문의해주세요',
+		],
 		BUTTON: '홈으로 이동',
 	},
 	[HTTP_STATUS_CODE.NOT_FOUND]: {
 		HEADING: '길을 잃으셨나요?',
-		BODY: {
-			firstLine: '페이지를 찾을 수 없습니다',
-			secondLine: '존재하지 않는 주소를 입력하셨거나',
-			thirdLine: '요청하신 페이지의 주소가 변경, 삭제되어 찾을 수 없습니다',
-		},
+		BODY: [
+			'페이지를 찾을 수 없습니다',
+			'존재하지 않는 주소를 입력하셨거나',
+			'요청하신 페이지의 주소가 변경, 삭제되어 찾을 수 없습니다',
+		],
 		BUTTON: '홈으로 이동',
 	},
 	[HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR]: {
 		HEADING: '앗, 뭔가 문제가 생겼어요..',
-		BODY: {
-			firstLine: '서비스와 연결할 수 없습니다',
-			secondLine: '문제를 해결하기 위해 열심히 노력하고 있습니다',
-			thirdLine: '잠시 후 다시 확인해주세요',
-		},
-		BUTTON: '홈으로 이동',
+		BODY: [
+			'서비스와 연결할 수 없습니다',
+			'문제를 해결하기 위해 열심히 노력하고 있습니다',
+			'잠시 후 다시 확인해주세요',
+		],
+		BUTTON: '다시 시도',
 	},
 	NETWORK: {
 		HEADING: '연결이 불안정해요',
-		BODY: {
-			firstLine: '서버에 연결하지 못했습니다',
-			secondLine: '네트워크 상태를 확인한 뒤',
-			thirdLine: '다시 시도해주세요',
-		},
+		BODY: ['서버에 연결하지 못했습니다', '네트워크 상태를 확인한 뒤', '다시 시도해주세요'],
 		BUTTON: '다시 시도',
 	},
 	DEFAULT: {
 		HEADING: '앗, 뭔가 문제가 생겼어요..',
-		BODY: {
-			firstLine: '일시적인 오류로 현재 요청사항을 처리하는데 실패했습니다',
-			secondLine: '잠시 후 다시 한 번 시도해주세요',
-			thirdLine: '지속적으로 발생할 경우 새로 고침하거나 다른 페이지로 이동해주세요',
-		},
+		BODY: [
+			'일시적인 오류로 현재 요청사항을 처리하는데 실패했습니다',
+			'잠시 후 다시 한 번 시도해주세요',
+			'지속적으로 발생할 경우 새로 고침하거나 다른 페이지로 이동해주세요',
+		],
 		BUTTON: '다시 시도',
 	},
-};
+} satisfies Record<PropertyKey, ErrorMessage>;
 
 export const AUTH_API_URL = {
 	KAKAO: `https://kauth.kakao.com/oauth/authorize?client_id=${import.meta.env.VITE_KAKAO_REST_API_KEY}&redirect_uri=${import.meta.env.VITE_KAKAO_REDIRECT_URL}&response_type=code`,

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -48,6 +48,8 @@ export const END_POINTS = {
 	POST_TEAMSPACE_ROLE: (teamspaceId: number) => `teamspaces/${teamspaceId}/tags`,
 } as const;
 
+export const VALIDATION_ERROR_CODE = 30001;
+
 export const AUTH_ERROR_CODE = {
 	INVALID_VERIFY_TOKEN: 40101,
 	INVALID_EMAIL_OR_PASSWORD: 40102,
@@ -132,6 +134,12 @@ export const HTTP_ERROR_MESSAGE = {
 		BUTTON: '다시 시도',
 	},
 } satisfies Record<PropertyKey, ErrorMessage>;
+
+export const COMMON_ERROR_MESSAGE = {
+	REQUEST_FAILED: '요청을 처리하지 못했어요. 잠시 후 다시 시도해 주세요',
+	NETWORK: '네트워크 상태를 확인한 뒤 다시 시도해 주세요',
+	TEAMSPACE_NOT_FOUND: '팀스페이스 정보를 찾을 수 없어요. 다시 시도해 주세요',
+} as const;
 
 export const AUTH_API_URL = {
 	KAKAO: `https://kauth.kakao.com/oauth/authorize?client_id=${import.meta.env.VITE_KAKAO_REST_API_KEY}&redirect_uri=${import.meta.env.VITE_KAKAO_REDIRECT_URL}&response_type=code`,

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -18,16 +18,13 @@ export const END_POINTS = {
 	PRESIGNED: 'presigned',
 	USERSETTING: 'users/settings',
 	FEEDS: (teamspaceId: number) => `teamspaces/${teamspaceId}/feeds`,
-	POST_NORMAL_FEED: (teamspaceId: number) =>
-		`teamspaces/${teamspaceId}/feeds/normal`,
-	POST_COLLECT_FEED: (teamspaceId: number) =>
-		`teamspaces/${teamspaceId}/feeds/collect`,
+	POST_NORMAL_FEED: (teamspaceId: number) => `teamspaces/${teamspaceId}/feeds/normal`,
+	POST_COLLECT_FEED: (teamspaceId: number) => `teamspaces/${teamspaceId}/feeds/collect`,
 	GET_COLLECT_SUB_TASK: (teamspaceId: number, feedId: number, userId: number) =>
 		`teamspaces/${teamspaceId}/feeds/collect/${feedId}/responses/users/${userId}`,
 	PATCH_COLLECT_SUB_TASK: (teamspaceId: number, feedId: number) =>
 		`teamspaces/${teamspaceId}/feeds/collect/${feedId}/responses`,
-	POST_SCHEDULING_FEED: (teamspaceId: number) =>
-		`teamspaces/${teamspaceId}/feeds/scheduling`,
+	POST_SCHEDULING_FEED: (teamspaceId: number) => `teamspaces/${teamspaceId}/feeds/scheduling`,
 	SCHEDULING_AVAIL: (teamspaceId: number, feedId: number) =>
 		`teamspaces/${teamspaceId}/feeds/scheduling/${feedId}/availabilities`,
 	POST_COMMENT: (teamspaceId: number, feedId: number) =>
@@ -38,24 +35,17 @@ export const END_POINTS = {
 		`teamspaces/${teamspaceId}/chat-channels/${chatChannelId}/messages`,
 	SUBSCRIBE: (teamspaceId: number, selectedChat: number) =>
 		`/topic/teamspaces/${teamspaceId}/chat-channels/${selectedChat}/messages`,
-	READ_MESSAGE: (
-		teamspaceId: number,
-		selectedChat: number,
-		messageId: number
-	) =>
+	READ_MESSAGE: (teamspaceId: number, selectedChat: number, messageId: number) =>
 		`/app/teamspaces/${teamspaceId}/chat-channels/${selectedChat}/messages/${messageId}/read`,
 	SEND_MESSAGE: (teamspaceId: number, selectedChat: number) =>
 		`/app/teamspaces/${teamspaceId}/chat-channels/${selectedChat}/messages`,
 	CHAT_CHANNEL_LIST: (teamspaceId: number, userId: number) =>
 		`/topic/teamspaces/${teamspaceId}/users/${userId}/chat-channels/status`,
-	RECEIVE_MESSAGE: (teamspaceId: number) =>
-		`/topic/teamspaces/${teamspaceId}/receive-message`,
+	RECEIVE_MESSAGE: (teamspaceId: number) => `/topic/teamspaces/${teamspaceId}/receive-message`,
 	SEND_CHAT_CHANNEL_LIST: (teamspaceId: number, userId: number) =>
 		`/app/teamspaces/${teamspaceId}/users/${userId}/chat-channels/status`,
-	GET_UNREAD_MESSAGE_COUNT: (teamspaceId: number) =>
-		`/teamspaces/${teamspaceId}/unread-count`,
-	POST_TEAMSPACE_ROLE: (teamspaceId: number) =>
-		`teamspaces/${teamspaceId}/tags`,
+	GET_UNREAD_MESSAGE_COUNT: (teamspaceId: number) => `/teamspaces/${teamspaceId}/unread-count`,
+	POST_TEAMSPACE_ROLE: (teamspaceId: number) => `teamspaces/${teamspaceId}/tags`,
 } as const;
 
 export const AUTH_ERROR_CODE = {
@@ -82,6 +72,7 @@ export const HTTP_STATUS_CODE = {
 	NO_CONTENT: 204,
 	BAD_REQUEST: 400,
 	UNAUTHORIZED: 401,
+	FORBIDDEN: 403,
 	NOT_FOUND: 404,
 	INTERNAL_SERVER_ERROR: 500,
 } as const;
@@ -93,12 +84,21 @@ export const ACCESS_TOKEN = 'ACCESS_TOKEN';
 export const INVITE_URL = 'INVITE_URL';
 
 export const HTTP_ERROR_MESSAGE = {
+	[HTTP_STATUS_CODE.FORBIDDEN]: {
+		HEADING: '접근 권한이 없어요',
+		BODY: {
+			firstLine: '이 페이지를 볼 수 있는 권한이 없습니다',
+			secondLine: '팀스페이스에서 나갔거나 권한이 변경되었을 수 있습니다',
+			thirdLine: '필요한 경우 팀스페이스 관리자에게 문의해주세요',
+		},
+		BUTTON: '홈으로 이동',
+	},
 	[HTTP_STATUS_CODE.NOT_FOUND]: {
 		HEADING: '길을 잃으셨나요?',
 		BODY: {
 			firstLine: '페이지를 찾을 수 없습니다',
 			secondLine: '존재하지 않는 주소를 입력하셨거나',
-			thridLine: '요청하신 페이지의 주소가 변경, 삭제되어 찾을 수 없습니다',
+			thirdLine: '요청하신 페이지의 주소가 변경, 삭제되어 찾을 수 없습니다',
 		},
 		BUTTON: '홈으로 이동',
 	},
@@ -107,17 +107,25 @@ export const HTTP_ERROR_MESSAGE = {
 		BODY: {
 			firstLine: '서비스와 연결할 수 없습니다',
 			secondLine: '문제를 해결하기 위해 열심히 노력하고 있습니다',
-			thridLine: '잠시 후 다시 확인해주세요',
+			thirdLine: '잠시 후 다시 확인해주세요',
 		},
 		BUTTON: '홈으로 이동',
+	},
+	NETWORK: {
+		HEADING: '연결이 불안정해요',
+		BODY: {
+			firstLine: '서버에 연결하지 못했습니다',
+			secondLine: '네트워크 상태를 확인한 뒤',
+			thirdLine: '다시 시도해주세요',
+		},
+		BUTTON: '다시 시도',
 	},
 	DEFAULT: {
 		HEADING: '앗, 뭔가 문제가 생겼어요..',
 		BODY: {
 			firstLine: '일시적인 오류로 현재 요청사항을 처리하는데 실패했습니다',
 			secondLine: '잠시 후 다시 한 번 시도해주세요',
-			thridLine:
-				'지속적으로 발생할 경우 새로 고침하거나 다른 페이지로 이동해주세요',
+			thirdLine: '지속적으로 발생할 경우 새로 고침하거나 다른 페이지로 이동해주세요',
 		},
 		BUTTON: '다시 시도',
 	},

--- a/src/hooks/queries/Feed/useFeedsQuery.ts
+++ b/src/hooks/queries/Feed/useFeedsQuery.ts
@@ -1,5 +1,5 @@
 import { GetFeedsParams, getFeeds } from '@apis/Feed/getFeeds';
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
 
 const useFeedsQuery = ({ teamspaceId, limit, type }: GetFeedsParams) => {
 	const {
@@ -7,7 +7,7 @@ const useFeedsQuery = ({ teamspaceId, limit, type }: GetFeedsParams) => {
 		hasNextPage,
 		isFetching,
 		fetchNextPage,
-	} = useInfiniteQuery({
+	} = useSuspenseInfiniteQuery({
 		queryKey: ['feeds', teamspaceId, type],
 		initialPageParam: undefined,
 		queryFn: ({ pageParam }) =>
@@ -20,10 +20,11 @@ const useFeedsQuery = ({ teamspaceId, limit, type }: GetFeedsParams) => {
 		getNextPageParam: (lastPage) => {
 			const lastFeedPage = lastPage.content.feeds;
 			const lastFeed = lastFeedPage[lastFeedPage.length - 1];
+
 			if (lastFeed) return lastFeed.feedId;
+
 			return undefined;
 		},
-		enabled: !!teamspaceId,
 	});
 
 	return { feeds, hasNextPage, isFetching, fetchNextPage };

--- a/src/hooks/queries/common/queryClient.ts
+++ b/src/hooks/queries/common/queryClient.ts
@@ -1,5 +1,6 @@
 import { QueryClient } from '@tanstack/react-query';
 import useToastStore from '@stores/toastStore';
+import { NetworkError } from '@apis/NetworkError';
 import { COMMON_ERROR_MESSAGE } from '@constants/api';
 
 export const queryClient = new QueryClient({
@@ -8,8 +9,13 @@ export const queryClient = new QueryClient({
 			throwOnError: true,
 		},
 		mutations: {
-			onError: () => {
-				useToastStore.getState().makeToast(COMMON_ERROR_MESSAGE.REQUEST_FAILED, 'Warning');
+			onError: (error) => {
+				const message =
+					error instanceof NetworkError
+						? COMMON_ERROR_MESSAGE.NETWORK
+						: COMMON_ERROR_MESSAGE.REQUEST_FAILED;
+
+				useToastStore.getState().makeToast(message, 'Warning');
 			},
 		},
 	},

--- a/src/hooks/queries/common/queryClient.ts
+++ b/src/hooks/queries/common/queryClient.ts
@@ -1,9 +1,16 @@
 import { QueryClient } from '@tanstack/react-query';
+import useToastStore from '@stores/toastStore';
+import { COMMON_ERROR_MESSAGE } from '@constants/api';
 
 export const queryClient = new QueryClient({
 	defaultOptions: {
 		queries: {
 			throwOnError: true,
+		},
+		mutations: {
+			onError: () => {
+				useToastStore.getState().makeToast(COMMON_ERROR_MESSAGE.REQUEST_FAILED, 'Warning');
+			},
 		},
 	},
 });

--- a/src/hooks/queries/common/useMutation.ts
+++ b/src/hooks/queries/common/useMutation.ts
@@ -1,5 +1,6 @@
 import { useMutation as useBaseMutation } from '@tanstack/react-query';
 import useToastStore from '@stores/toastStore';
+import { NetworkError } from '@apis/NetworkError';
 import { COMMON_ERROR_MESSAGE } from '@constants/api';
 
 type FetchFn<T> = () => Promise<T>;
@@ -12,14 +13,21 @@ type Props<T> = {
  * @deprecated
  */
 export const useMutation = <T>({ onSuccess, onError }: Props<T>) => {
-	const { makeToast } = useToastStore();
-
 	const { mutateAsync, isPending } = useBaseMutation({
 		mutationFn: (fetchFn: FetchFn<T>) => fetchFn(),
 		onSuccess,
 		onError: (error: Error) => {
-			if (onError) onError(error);
-			else makeToast(COMMON_ERROR_MESSAGE.REQUEST_FAILED, 'Warning');
+			if (onError) {
+				onError(error);
+				return;
+			}
+
+			const message =
+				error instanceof NetworkError
+					? COMMON_ERROR_MESSAGE.NETWORK
+					: COMMON_ERROR_MESSAGE.REQUEST_FAILED;
+
+			useToastStore.getState().makeToast(message, 'Warning');
 		},
 	});
 

--- a/src/hooks/queries/common/useMutation.ts
+++ b/src/hooks/queries/common/useMutation.ts
@@ -1,5 +1,6 @@
-import { useState } from 'react';
-import { HTTPError } from '@apis/HTTPError';
+import { useMutation as useBaseMutation } from '@tanstack/react-query';
+import useToastStore from '@stores/toastStore';
+import { COMMON_ERROR_MESSAGE } from '@constants/api';
 
 type FetchFn<T> = () => Promise<T>;
 type Props<T> = {
@@ -7,24 +8,28 @@ type Props<T> = {
 	onError?: (error: Error) => void;
 };
 
+/**
+ * @deprecated
+ */
 export const useMutation = <T>({ onSuccess, onError }: Props<T>) => {
-	const [error, setError] = useState<HTTPError | null>(null);
+	const { makeToast } = useToastStore();
 
-	// eslint-disable-next-line consistent-return
+	const { mutateAsync, isPending } = useBaseMutation({
+		mutationFn: (fetchFn: FetchFn<T>) => fetchFn(),
+		onSuccess,
+		onError: (error: Error) => {
+			if (onError) onError(error);
+			else makeToast(COMMON_ERROR_MESSAGE.REQUEST_FAILED, 'Warning');
+		},
+	});
+
 	const mutate = async (fetchFn: FetchFn<T>) => {
 		try {
-			const data = await fetchFn();
-			if (onSuccess) onSuccess(data);
-			return data;
-		} catch (err) {
-			if (err instanceof HTTPError) {
-				if (!onError) setError(err);
-				else onError(err);
-			}
+			return await mutateAsync(fetchFn);
+		} catch {
+			return undefined; // 기존 동작 유지
 		}
 	};
 
-	if (error) throw error;
-
-	return { mutate };
+	return { mutate, isPending };
 };

--- a/src/hooks/queries/post/useSchedulingPostMutation.tsx
+++ b/src/hooks/queries/post/useSchedulingPostMutation.tsx
@@ -1,43 +1,63 @@
 import { useErrorBoundary } from 'react-error-boundary';
 import { useNavigate } from 'react-router-dom';
 import postSchedulingFeed from '@apis/post/postSchedulingFeed';
-import { useMutation } from '@hooks/queries/common/useMutation';
 import { useLastSeenTeamspaceId } from '@hooks/user/useLastSeenTeamspaceId';
+import { useMutation } from '@tanstack/react-query';
 import { calcTimeSegment } from '@utils/post/scheduling/timeOptionUtils';
 import useToastStore from '@stores/toastStore';
 import { HTTPError } from '@apis/HTTPError';
+import { NetworkError } from '@apis/NetworkError';
+import { COMMON_ERROR_MESSAGE, VALIDATION_ERROR_CODE } from '@constants/api';
 import { PATH } from '@constants/path';
 import type { SchedulingPostFormData, SchedulingPostRequest } from '@type/post';
+
+const SCHEDULING_POST_MESSAGE = {
+	SUCCESS: '일정 조율 피드를 작성했어요',
+	INVALID: '입력한 내용이 올바르지 않아요. 다시 확인해 주세요',
+	FAILED: '일정 조율 피드 작성에 실패했어요. 잠시 후 다시 시도해 주세요',
+} as const;
+
+interface SchedulingPostVariables {
+	request: SchedulingPostRequest;
+	teamspaceId: number;
+}
 
 const useSchedulingPostMutation = () => {
 	const { makeToast } = useToastStore();
 	const { showBoundary } = useErrorBoundary();
+
 	const navigate = useNavigate();
 	const teamspaceId = useLastSeenTeamspaceId();
 
-	const handleSchedulingFeedSuccess = () => {
-		makeToast('일정 조율 피드 작성 성공', 'Success');
-		navigate(PATH.FEED);
-	};
-
-	const handleSchedulingFeedError = (error: Error) => {
-		if (error instanceof HTTPError) {
-			makeToast('일정 조율 피드 작성을 실패했어요. 마감일시를 확인해 주세요', 'Warning');
-		} else showBoundary(error);
-	};
-
-	const { mutate } = useMutation({
-		onSuccess: handleSchedulingFeedSuccess,
-		onError: handleSchedulingFeedError,
+	const { mutate, isPending } = useMutation({
+		mutationFn: ({ request, teamspaceId: id }: SchedulingPostVariables) =>
+			postSchedulingFeed(request, id),
+		onSuccess: () => {
+			makeToast(SCHEDULING_POST_MESSAGE.SUCCESS, 'Success');
+			navigate(PATH.FEED);
+		},
+		onError: (error: Error) => {
+			if (error instanceof HTTPError) {
+				switch (error.code) {
+					case VALIDATION_ERROR_CODE:
+						makeToast(SCHEDULING_POST_MESSAGE.INVALID, 'Warning');
+						break;
+					default:
+						makeToast(SCHEDULING_POST_MESSAGE.FAILED, 'Warning');
+				}
+			} else if (error instanceof NetworkError) {
+				makeToast(COMMON_ERROR_MESSAGE.NETWORK, 'Warning');
+			} else showBoundary(error);
+		},
 	});
 
-	const mutateSchedulingPost = async (formData: SchedulingPostFormData) => {
+	const mutateSchedulingPost = (formData: SchedulingPostFormData) => {
 		if (teamspaceId === undefined) {
-			makeToast('팀스페이스 정보를 찾을 수 없어요. 다시 시도해 주세요', 'Warning');
+			makeToast(COMMON_ERROR_MESSAGE.TEAMSPACE_NOT_FOUND, 'Warning');
 			return;
 		}
 
-		const convertedFormData: SchedulingPostRequest = {
+		const request: SchedulingPostRequest = {
 			title: formData.title,
 			details: {
 				dueAt: `${formData.dueAtDate} ${formData.dueAtTime}`,
@@ -47,10 +67,10 @@ const useSchedulingPostMutation = () => {
 			},
 		};
 
-		await mutate(() => postSchedulingFeed(convertedFormData, teamspaceId));
+		mutate({ request, teamspaceId });
 	};
 
-	return { mutateSchedulingPost };
+	return { mutateSchedulingPost, isPending };
 };
 
 export default useSchedulingPostMutation;

--- a/src/hooks/queries/useRegisterMutation.tsx
+++ b/src/hooks/queries/useRegisterMutation.tsx
@@ -1,41 +1,55 @@
 import { useErrorBoundary } from 'react-error-boundary';
 import { useNavigate } from 'react-router-dom';
 import postRegister from '@apis/user/postRegister';
-import { useMutation } from '@hooks/queries/common/useMutation';
+import { useMutation } from '@tanstack/react-query';
 import useToastStore from '@stores/toastStore';
 import { HTTPError } from '@apis/HTTPError';
+import { NetworkError } from '@apis/NetworkError';
+import { AUTH_ERROR_CODE, COMMON_ERROR_MESSAGE, VALIDATION_ERROR_CODE } from '@constants/api';
 import { PATH } from '@constants/path';
 import type { RegisterData } from '@apis/user/postRegister';
+
+const REGISTER_MESSAGE = {
+	SUCCESS: '회원가입에 성공했습니다',
+	INVALID_FORMAT: '가입 형식을 확인해주세요',
+	UNVERIFIED_MAIL: '인증된 메일이 아니거나 인증 정보가 만료됐습니다',
+	DUPLICATED_MAIL: '이미 가입된 메일입니다',
+	FAILED: '회원가입에 실패했습니다. 잠시 후 다시 시도해 주세요',
+} as const;
 
 const useRegisterMutation = () => {
 	const { makeToast } = useToastStore();
 	const { showBoundary } = useErrorBoundary();
+
 	const navigate = useNavigate();
 
-	const handleRegisterError = (error: Error) => {
-		if (error instanceof HTTPError) {
-			if (error.code === 30001) {
-				makeToast('가입 형식을 확인해주세요', 'Warning');
-			} else if (error.code === 40103) {
-				makeToast('인증된 메일이 아니거나 인증 정보가 만료됐습니다', 'Warning');
-			} else if (error.code === 40104) {
-				makeToast('이미 가입된 메일입니다', 'Warning');
-			}
-		} else showBoundary(error);
-	};
-
-	const { mutate } = useMutation({
+	const { mutate: mutateRegister, isPending } = useMutation({
+		mutationFn: (data: RegisterData) => postRegister(data),
 		onSuccess: () => {
-			makeToast('회원가입 성공', 'Success');
+			makeToast(REGISTER_MESSAGE.SUCCESS, 'Success');
 			navigate(PATH.SIGNIN);
 		},
-		onError: handleRegisterError,
+		onError: (error: Error) => {
+			if (error instanceof HTTPError) {
+				switch (error.code) {
+					case VALIDATION_ERROR_CODE:
+						makeToast(REGISTER_MESSAGE.INVALID_FORMAT, 'Warning');
+						break;
+					case AUTH_ERROR_CODE.UNAUTHORIZED_OR_EXPIRED_VERIFY_TOKEN:
+						makeToast(REGISTER_MESSAGE.UNVERIFIED_MAIL, 'Warning');
+						break;
+					case AUTH_ERROR_CODE.DUPLICATED_USER_EMAIL:
+						makeToast(REGISTER_MESSAGE.DUPLICATED_MAIL, 'Warning');
+						break;
+					default:
+						makeToast(REGISTER_MESSAGE.FAILED, 'Warning');
+				}
+			} else if (error instanceof NetworkError) {
+				makeToast(COMMON_ERROR_MESSAGE.NETWORK, 'Warning');
+			} else showBoundary(error);
+		},
 	});
 
-	const mutateRegister = async (data: RegisterData) => {
-		mutate(() => postRegister(data));
-	};
-
-	return { mutateRegister };
+	return { mutateRegister, isPending };
 };
 export default useRegisterMutation;

--- a/src/pages/FeedPage/FeedPage.tsx
+++ b/src/pages/FeedPage/FeedPage.tsx
@@ -1,17 +1,16 @@
 import { useCallback, useState } from 'react';
-import InfiniteScroll from 'react-infinite-scroller';
+import AsyncBoundary from '@components/common/AsyncBoundary/AsyncBoundary';
 import Divider from '@components/common/Divider/Divider';
 import Heading from '@components/common/Heading/Heading';
 import Select from '@components/common/Select/Select';
-import Feed from '@components/Feed/Feed';
+import FeedList from '@components/Feed/FeedList/FeedList';
+import FeedSkeletonList from '@components/Feed/FeedSkeletonList/FeedSkeletonList';
 import useMeasureWidth from '@hooks/common/useMeasureWidth';
 import useFeedDrawer from '@hooks/post/useFeedDrawer';
 import { queryClient } from '@hooks/queries/common/queryClient';
-import useFeedsQuery from '@hooks/queries/Feed/useFeedsQuery';
 import useUserStatusQuery from '@hooks/queries/useUserStatusQuery';
-import { getSanitizedFeeds } from '@utils/getSanitizedFeeds';
 import { FEED_SELECT_MAP } from '@constants/feed';
-import type { FeedData, SelectType } from '@type/feed';
+import type { SelectType } from '@type/feed';
 import * as S from './FeedPage.styled';
 
 const FeedPage = () => {
@@ -37,23 +36,16 @@ const FeedPage = () => {
 		});
 	};
 
-	const { feeds, hasNextPage, isFetching, fetchNextPage } = useFeedsQuery({
-		teamspaceId,
-		type: getTypeBySelect(selectedType),
-	});
-
 	const getAdjustedWidth = useCallback((refWidth: number) => {
 		const space = Math.max((refWidth - 760) / 2, 0);
 		return space > 200 ? 200 : space;
 	}, []);
 
-	if (!teamspaceId) return <div>Loading..</div>;
+	const type = getTypeBySelect(selectedType);
 
 	return (
 		<S.Container ref={containerRef}>
-			<S.FeedHeaderContainer
-				isOpen={openFeedId !== null}
-				adjustedWidth={getAdjustedWidth(width)}>
+			<S.FeedHeaderContainer isOpen={openFeedId !== null} adjustedWidth={getAdjustedWidth(width)}>
 				<S.FeedHeader>
 					<Heading size='xs' color='primary'>
 						피드
@@ -69,33 +61,20 @@ const FeedPage = () => {
 				</S.FeedHeader>
 				<Divider size='sm' />
 			</S.FeedHeaderContainer>
-			<S.FeedsWrapper
-				isOpen={openFeedId !== null}
-				adjustedWidth={getAdjustedWidth(width)}>
-				<InfiniteScroll
-					loadMore={() => {
-						if (!isFetching) fetchNextPage();
-					}}
-					hasMore={hasNextPage}
-					useWindow={false}>
-					{feeds?.pages.map((pageData) => {
-						const sanitizedFeeds = getSanitizedFeeds(pageData.content.feeds);
-
-						return sanitizedFeeds.map((feedData: FeedData) => {
-							const { feedId } = feedData;
-
-							return (
-								<Feed
-									key={feedId}
-									feedData={feedData}
-									isDetailOpen={isDrawerOpen(feedId)}
-									openDetail={() => openDrawer(feedId)}
-									closeDetail={closeDrawer}
-								/>
-							);
-						});
-					})}
-				</InfiniteScroll>
+			<S.FeedsWrapper isOpen={openFeedId !== null} adjustedWidth={getAdjustedWidth(width)}>
+				{teamspaceId ? (
+					<AsyncBoundary loadingFallback={<FeedSkeletonList />} resetKeys={[teamspaceId, type]}>
+						<FeedList
+							teamspaceId={teamspaceId}
+							type={type}
+							isDrawerOpen={isDrawerOpen}
+							openDrawer={openDrawer}
+							closeDrawer={closeDrawer}
+						/>
+					</AsyncBoundary>
+				) : (
+					<FeedSkeletonList />
+				)}
 			</S.FeedsWrapper>
 		</S.Container>
 	);

--- a/src/pages/NotFoundPage/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage/NotFoundPage.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import Error from '@components/common/Error/Error';
-import { HTTP_STATUS_CODE } from '@constants/api';
+import { HTTP_ERROR_MESSAGE, HTTP_STATUS_CODE } from '@constants/api';
 import { PATH } from '@constants/path';
 
 const NotFoundPage = () => {
@@ -8,7 +8,7 @@ const NotFoundPage = () => {
 
 	return (
 		<Error
-			errorCode={HTTP_STATUS_CODE.NOT_FOUND}
+			errorMessage={HTTP_ERROR_MESSAGE[HTTP_STATUS_CODE.NOT_FOUND]}
 			resetError={() => navigate(PATH.ROOT)}
 		/>
 	);

--- a/src/pages/SignUpPage/SignUpPage.tsx
+++ b/src/pages/SignUpPage/SignUpPage.tsx
@@ -18,12 +18,12 @@ const SignUpPage = () => {
 	const navigate = useNavigate();
 	const { mutateDuplication } = useDuplicationMutation();
 	const { mutateVerification } = useVerificationMutation();
-	const { mutateRegister } = useRegisterMutation();
+	const { mutateRegister, isPending } = useRegisterMutation();
 
 	const { formData, submitting, errors, register, handleSubmit } = useForm({
 		subscribe: [{ fieldName: 'verifyCode', value: verified }],
-		onSubmit: async () => {
-			await mutateRegister({
+		onSubmit: () => {
+			mutateRegister({
 				username: formData.username,
 				password: formData.password,
 				email: formData.email,
@@ -197,19 +197,14 @@ const SignUpPage = () => {
 					size='lg'
 					variant='primary'
 					isFull
-					disabled={submitting}
+					disabled={submitting || isPending}
 				/>
 			</S.FormContainer>
 			<Flex align='center'>
 				<Text size='md' weight='regular'>
 					계정이 있나요?
 				</Text>
-				<Button
-					label='로그인하기'
-					variant='text'
-					size='md'
-					onClick={() => navigate(PATH.SIGNIN)}
-				/>
+				<Button label='로그인하기' variant='text' size='md' onClick={() => navigate(PATH.SIGNIN)} />
 			</Flex>
 		</S.Container>
 	);

--- a/src/styles/layout.ts
+++ b/src/styles/layout.ts
@@ -15,3 +15,7 @@ export const MODAL_WIDTH = 320;
 export const MODAL_HEIGHT = 180;
 
 export const FEED_DETAIL_MAX_HEIGHT = 400;
+
+export const FEED_CARD_WIDTH = 680;
+
+export const FEED_BODY_MIN_HEIGHT = 150;


### PR DESCRIPTION
## 📌 관련 이슈

- https://github.com/98OO/colla-frontend/issues/223

## ✨ PR 세부 내용

에러 발생 시 화면 전체를 fallback으로 대체 또는 로그아웃 처리를 했던 기존 로직의 결함을 수정하고, 에러 및 로딩 처리 구조를 개선했습니다

<br/>

**에러 표준화**

인터셉터에서 발생한 에러를 판별 가능한 형태로 표준화하도록 수정했습니다

| 에러 상황 | 변환 결과 |
|------|--------|
| 응답 수신 성공 | `HTTPError` (status 및 code 보존) |
| 응답 수신 실패 | `NetworkError` |
| 그 외 | 변환하지 않음 (런타임 코드 결함) |

- 네트워크 단절·타임아웃 등 응답 자체가 없는 에러를 명확히 구분할 수 있도록 `NetworkError` 클래스를 추가
- 5xx 에러의 상태 코드·서버 정보를 유지하도록 변경
- 응답이 없는 케이스와 원본 요청이 없는 케이스의 조건을 분리하도록 변경

<br/>

**에러 fallback 처리 결함 수정**

| 에러 타입 | 안내메시지와 복구 동작 |
|------|--------|
| `NetworkError` | 연결 안내 + 재시도 |
| `403`·`404` | 홈 이동 |
| `5xx` | 재시도 (`QueryErrorResetBoundary`의 reset과 연동) |
| 그 외 | 기본 안내 |

- 에러 fallback 내 로그아웃 로직을 제거해 결함을 수정
- 에러 타입에 따라 안내 메시지와 복구 동작을 처리하도록 수정

<br/>

**`AsyncBoundary` 도입과 라우트 단위 배치**

동일한 비동기 작업의 로딩과 에러를 한 자리에서 처리하도록 구조를 추가했습니다

- `ErrorBoundary`와 `Suspense`를 결합한 `AsyncBoundary`를 추가
- 에러가 GNB·SNB로 넘어가지 않도록 `<Outlet/>`에 배치
- 페이지 이동 시 fallback이 남지 않도록 `resetKeys`에 `location.pathname`을 설정
- `GlobalErrorBoundary`는 처리되지 않은 에러를 받는 바운더리로 역할을 조정

<br/>

**공통 `useMutation` 정리**

기존 공통 훅은 `mutation` 에러를 전역 `ErrorBoundary`로 보내기 위해 에러를 `state`에 담았다가 렌더 중 다시 throw하는 구조였습니다. `ErrorBoundary`가 렌더 중 throw만 잡기 때문에 비동기 컨텍스트의 에러를 렌더 컨텍스트로 옮기려는 우회였고, TanStack이 `throwOnError`로 이미 제공하는 기능의 재구현이었습니다. 또한 `mutation` 실패는 화면이 유지되는 상황이므로 fallback이 아니라 토스트 메시지 안내가 적절합니다

- 사용처가 많아 시그니처는 유지하고 내부만 TanStack 기반으로 교체 후 `@deprecated` 표기
- 전역 기본 처리를 `defaultOptions.mutations.onError`에 추가 (`MutationCache`는 "항상 실행"이 필요한 관심사가 없어 미채택)
- `useSchedulingPostMutation`·`useRegisterMutation` 2곳을 직접 사용 방식으로 전환

<br/>

**Skeleton + 본문 Suspense**

빈 화면으로 노출되던 로딩 구간에 skeleton을 추가하고, 로딩·에러 처리를 바운더리로 위임하도록 변경했습니다

- `width`·`height`·`radius` 3개 prop만 받는 공통 `Skeleton` 추가 (애니메이션·색은 내장, 배치는 `Flex` 조합이 담당)
- `useFeedsQuery`를 `useSuspenseInfiniteQuery`로 변경하고, 본문을 `FeedList`로 추출해 `AsyncBoundary`로 감싸도록 변경

<br/>

**이번 PR 범위 밖**

인터셉터를 수정하며 확인했으나 재발급 흐름 설계와 함께 다뤄야 하는 항목이라 별도 PR에서 진행할 예정입니다

- 토큰 재발급 동시성
- 재시도 1회성 보장
- 재발급 실패 시 리다이렉트 정책
- `ErrorResponse` 타입 정합성

후속 PR에서 재발급 흐름을 중심으로 재작성될 예정으로 이번 PR은 최소 수정했습니다


## 📸 스크린샷
https://github.com/user-attachments/assets/14a612da-2661-45a5-aa3c-808df067e9a2


## ✅ 리뷰 요구사항

**공통 `useMutation` 전환 시 주의사항**

`onError` 키를 넘기면 `defaultOptions`의 전역 기본 처리가 대체되므로, 전역 기본 Toast에 맡기시려면 키 자체를 넘기지 않아야 합니다

```ts
// 전역 기본 Toast에 맡김
useMutation({ mutationFn });

// 직접 처리 (전역 기본은 발동하지 않음)
useMutation({ mutationFn, onError: (error) => { ... } });
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 피드 목록에 무한 스크롤과 페이지 단위 추가 로딩을 지원합니다.
  - 피드 데이터를 불러오는 동안 스켈레톤 로딩 화면을 제공합니다.
  - 화면 전환 및 데이터 변경 시 로딩·오류 상태가 안정적으로 초기화됩니다.
  - 네트워크 오류, 권한 오류, 서버 오류에 맞는 안내와 복구 동작을 제공합니다.

- **버그 수정**
  - 네트워크 및 API 오류 메시지 표시를 개선했습니다.
  - 회원가입과 예약 게시물 등록 중 중복 제출을 방지합니다.
  - 피드 카드와 본문 영역의 크기 및 정렬 일관성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->