### PR TITLE
채팅 가상 스크롤 및 네트워크 복구 흐름 개선

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"dependencies": {
 				"@stomp/stompjs": "^7.0.0",
 				"@tanstack/react-query": "^5.29.0",
+				"@tanstack/react-virtual": "^3.14.9",
 				"@tiptap/extension-image": "^2.9.1",
 				"@tiptap/extension-text-align": "^2.9.1",
 				"@tiptap/extension-underline": "^2.9.1",
@@ -2001,73 +2002,6 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@bundled-es-modules/cookie": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.1.tgz",
-			"integrity": "sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"cookie": "^0.7.2"
-			}
-		},
-		"node_modules/@bundled-es-modules/statuses": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz",
-			"integrity": "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"statuses": "^2.0.1"
-			}
-		},
-		"node_modules/@bundled-es-modules/tough-cookie": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/@bundled-es-modules/tough-cookie/-/tough-cookie-0.1.6.tgz",
-			"integrity": "sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@types/tough-cookie": "^4.0.5",
-				"tough-cookie": "^4.1.4"
-			}
-		},
-		"node_modules/@bundled-es-modules/tough-cookie/node_modules/tough-cookie": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
-			"integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"psl": "^1.1.33",
-				"punycode": "^2.1.1",
-				"universalify": "^0.2.0",
-				"url-parse": "^1.5.3"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/@bundled-es-modules/tough-cookie/node_modules/universalify": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-			"integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">= 4.0.0"
-			}
-		},
 		"node_modules/@chromatic-com/storybook": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/@chromatic-com/storybook/-/storybook-5.2.1.tgz",
@@ -3551,134 +3485,6 @@
 			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
 			"dev": true
 		},
-		"node_modules/@inquirer/ansi": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
-			"integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
-			}
-		},
-		"node_modules/@inquirer/confirm": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.0.1.tgz",
-			"integrity": "sha512-6ycMm7k7NUApiMGfVc32yIPp28iPKxhGRMqoNDiUjq2RyTAkbs5Fx0TdzBqhabcKvniDdAAvHCmsRjnNfTsogw==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@inquirer/core": "^10.0.1",
-				"@inquirer/type": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"@types/node": ">=18"
-			}
-		},
-		"node_modules/@inquirer/core": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.0.1.tgz",
-			"integrity": "sha512-KKTgjViBQUi3AAssqjUFMnMO3CM3qwCHvePV9EW+zTKGKafFGFF01sc1yOIYjLJ7QU52G/FbzKc+c01WLzXmVQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@inquirer/figures": "^1.0.7",
-				"@inquirer/type": "^3.0.0",
-				"ansi-escapes": "^4.3.2",
-				"cli-width": "^4.1.0",
-				"mute-stream": "^2.0.0",
-				"signal-exit": "^4.1.0",
-				"strip-ansi": "^6.0.1",
-				"wrap-ansi": "^6.2.0",
-				"yoctocolors-cjs": "^2.1.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@inquirer/core/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/@inquirer/core/node_modules/cli-width": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-			"integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">= 12"
-			}
-		},
-		"node_modules/@inquirer/core/node_modules/mute-stream": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
-			"integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/@inquirer/core/node_modules/signal-exit": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@inquirer/core/node_modules/wrap-ansi": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/@inquirer/external-editor": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
@@ -3716,33 +3522,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/@inquirer/figures": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.7.tgz",
-			"integrity": "sha512-m+Trk77mp54Zma6xLkLuY+mvanPxlE4A7yNKs2HBiyZ4UkVs28Mv5c/pgWrHeInx+USHeX/WEPzjrWrcJiQgjw==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@inquirer/type": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.0.tgz",
-			"integrity": "sha512-YYykfbw/lefC7yKj7nanzQXILM7r3suIvyFlCcMskc99axmsSewXWkAfXKwMbgxL76iAFVmRwmYdwNZNc8gjog==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"@types/node": ">=18"
 			}
 		},
 		"node_modules/@joshwooding/vite-plugin-react-docgen-typescript": {
@@ -3990,28 +3769,6 @@
 			},
 			"engines": {
 				"node": ">= 8"
-			}
-		},
-		"node_modules/@open-draft/deferred-promise": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
-			"integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@open-draft/logger": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
-			"integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"is-node-process": "^1.2.0",
-				"outvariant": "^1.4.0"
 			}
 		},
 		"node_modules/@open-draft/until": {
@@ -4666,15 +4423,6 @@
 			"funding": {
 				"url": "https://opencollective.com/unts"
 			}
-		},
-		"node_modules/@polka/url": {
-			"version": "1.0.0-next.28",
-			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.28.tgz",
-			"integrity": "sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
 		},
 		"node_modules/@popperjs/core": {
 			"version": "2.11.8",
@@ -5694,6 +5442,33 @@
 				"react": "^18.0.0"
 			}
 		},
+		"node_modules/@tanstack/react-virtual": {
+			"version": "3.14.9",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.9.tgz",
+			"integrity": "sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@tanstack/virtual-core": "3.17.7"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@tanstack/virtual-core": {
+			"version": "3.17.7",
+			"resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.7.tgz",
+			"integrity": "sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			}
+		},
 		"node_modules/@testing-library/dom": {
 			"version": "10.4.0",
 			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
@@ -6534,24 +6309,6 @@
 			"integrity": "sha512-zk+uFZeWyvJ5ZFkLIwoGA/DfJ+pYzcZ8eH4H/EILCm2OBZyHH6Hkdna1/UWL/CFruh5wj6ES7g75SvUB0VsH5w==",
 			"dev": true
 		},
-		"node_modules/@types/statuses": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
-			"integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@types/tough-cookie": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
-			"integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
-		},
 		"node_modules/@types/trusted-types": {
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -6833,321 +6590,6 @@
 			},
 			"peerDependencies": {
 				"vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
-			}
-		},
-		"node_modules/@vitest/browser": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-2.1.3.tgz",
-			"integrity": "sha512-PQ2kLLc9q8ukJutuuYsynHSr31E78/dtYEvPy4jCHLht1LmITqXTVTqu7THWdZ1kXNGrWwtdMqtt3z2mvSKdIg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@testing-library/dom": "^10.4.0",
-				"@testing-library/user-event": "^14.5.2",
-				"@vitest/mocker": "2.1.3",
-				"@vitest/utils": "2.1.3",
-				"magic-string": "^0.30.11",
-				"msw": "^2.3.5",
-				"sirv": "^2.0.4",
-				"tinyrainbow": "^1.2.0",
-				"ws": "^8.18.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			},
-			"peerDependencies": {
-				"playwright": "*",
-				"vitest": "2.1.3",
-				"webdriverio": "*"
-			},
-			"peerDependenciesMeta": {
-				"playwright": {
-					"optional": true
-				},
-				"safaridriver": {
-					"optional": true
-				},
-				"webdriverio": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/@mswjs/interceptors": {
-			"version": "0.36.6",
-			"resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.36.6.tgz",
-			"integrity": "sha512-issnYydStyH0wPEeU7CMwfO7kI668ffVtzKRMRS7H7BliOYuPuwEZxh9dwiXV+oeHBxT5SXT0wPwV8T7V2PJUA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@open-draft/deferred-promise": "^2.2.0",
-				"@open-draft/logger": "^0.3.0",
-				"@open-draft/until": "^2.0.0",
-				"is-node-process": "^1.2.0",
-				"outvariant": "^1.4.3",
-				"strict-event-emitter": "^0.5.1"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/@open-draft/until": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
-			"integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@vitest/browser/node_modules/@types/cookie": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
-			"integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@vitest/browser/node_modules/@vitest/mocker": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.3.tgz",
-			"integrity": "sha512-eSpdY/eJDuOvuTA3ASzCjdithHa+GIF1L4PqtEELl6Qa3XafdMLBpBlZCIUCX2J+Q6sNmjmxtosAG62fK4BlqQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@vitest/spy": "2.1.3",
-				"estree-walker": "^3.0.3",
-				"magic-string": "^0.30.11"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			},
-			"peerDependencies": {
-				"@vitest/spy": "2.1.3",
-				"msw": "^2.3.5",
-				"vite": "^5.0.0"
-			},
-			"peerDependenciesMeta": {
-				"msw": {
-					"optional": true
-				},
-				"vite": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/@vitest/spy": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.3.tgz",
-			"integrity": "sha512-Nb2UzbcUswzeSP7JksMDaqsI43Sj5+Kry6ry6jQJT4b5gAK+NS9NED6mDb8FlMRCX8m5guaHCDZmqYMMWRy5nQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"tinyspy": "^3.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/@vitest/utils": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.3.tgz",
-			"integrity": "sha512-xpiVfDSg1RrYT0tX6czgerkpcKFmFOF/gCr30+Mve5V2kewCy4Prn1/NDMSRwaSmT7PRaOF83wu+bEtsY1wrvA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@vitest/pretty-format": "2.1.3",
-				"loupe": "^3.1.1",
-				"tinyrainbow": "^1.2.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/estree-walker": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@types/estree": "^1.0.0"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/has-flag": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/headers-polyfill": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
-			"integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@vitest/browser/node_modules/loupe": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.2.tgz",
-			"integrity": "sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@vitest/browser/node_modules/msw": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/msw/-/msw-2.5.1.tgz",
-			"integrity": "sha512-V0BmHvFkbWGXqbyrc+XiuQ8DU3qzcb6lb8gB9Vzltp3cgHLHLCDF/KmmFo0xw58StNaRMTebw3/xpWVvU9xq9g==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@bundled-es-modules/cookie": "^2.0.0",
-				"@bundled-es-modules/statuses": "^1.0.1",
-				"@bundled-es-modules/tough-cookie": "^0.1.6",
-				"@inquirer/confirm": "^5.0.0",
-				"@mswjs/interceptors": "^0.36.5",
-				"@open-draft/until": "^2.1.0",
-				"@types/cookie": "^0.6.0",
-				"@types/statuses": "^2.0.4",
-				"chalk": "^4.1.2",
-				"graphql": "^16.8.1",
-				"headers-polyfill": "^4.0.2",
-				"is-node-process": "^1.2.0",
-				"outvariant": "^1.4.3",
-				"path-to-regexp": "^6.3.0",
-				"strict-event-emitter": "^0.5.1",
-				"type-fest": "^4.26.1",
-				"yargs": "^17.7.2"
-			},
-			"bin": {
-				"msw": "cli/index.js"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/mswjs"
-			},
-			"peerDependencies": {
-				"typescript": ">= 4.8.x"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/strict-event-emitter": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
-			"integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@vitest/browser/node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/tinyspy": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
-			"integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@vitest/browser/node_modules/type-fest": {
-			"version": "4.26.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.1.tgz",
-			"integrity": "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
@@ -8323,18 +7765,6 @@
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
 			"dev": true
-		},
-		"node_modules/cookie": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">= 0.6"
-			}
 		},
 		"node_modules/core-js-compat": {
 			"version": "3.37.0",
@@ -10210,27 +9640,6 @@
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
 		},
-		"node_modules/fast-string-truncated-width": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
-			"integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/fast-string-width": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
-			"integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"fast-string-truncated-width": "^3.0.2"
-			}
-		},
 		"node_modules/fast-uri": {
 			"version": "3.1.4",
 			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
@@ -10247,18 +9656,6 @@
 				}
 			],
 			"license": "BSD-3-Clause"
-		},
-		"node_modules/fast-wrap-ansi": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
-			"integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"fast-string-width": "^3.0.2"
-			}
 		},
 		"node_modules/fastq": {
 			"version": "1.17.1",
@@ -12594,18 +11991,6 @@
 				"node": ">=16 || 14 >=14.17"
 			}
 		},
-		"node_modules/mrmime": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.0.tgz",
-			"integrity": "sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -13730,15 +13115,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/psl": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-			"integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
-		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -14156,15 +13532,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/rettime": {
-			"version": "0.11.11",
-			"resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.11.tgz",
-			"integrity": "sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
-		},
 		"node_modules/reusify": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -14561,23 +13928,6 @@
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"dev": true
 		},
-		"node_modules/sirv": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
-			"integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@polka/url": "^1.0.0-next.24",
-				"mrmime": "^2.0.0",
-				"totalist": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 10"
-			}
-		},
 		"node_modules/slash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -14688,18 +14038,6 @@
 			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/statuses": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
-			"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">= 0.8"
-			}
 		},
 		"node_modules/std-env": {
 			"version": "3.7.0",
@@ -15218,21 +14556,6 @@
 				"url": "https://opencollective.com/unts"
 			}
 		},
-		"node_modules/tagged-tag": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
-			"integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/text-extensions": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-2.4.0.tgz",
@@ -15385,18 +14708,6 @@
 			},
 			"engines": {
 				"node": ">=8.0"
-			}
-		},
-		"node_modules/totalist": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
-			"integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/tough-cookie": {
@@ -15705,18 +15016,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/until-async": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
-			"integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"funding": {
-				"url": "https://github.com/sponsors/kettanaito"
 			}
 		},
 		"node_modules/update-browserslist-db": {
@@ -16391,120 +15690,6 @@
 				}
 			}
 		},
-		"node_modules/vitest/node_modules/@inquirer/confirm": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
-			"integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@inquirer/core": "^11.2.1",
-				"@inquirer/type": "^4.0.7"
-			},
-			"engines": {
-				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
-			},
-			"peerDependencies": {
-				"@types/node": ">=18"
-			},
-			"peerDependenciesMeta": {
-				"@types/node": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/vitest/node_modules/@inquirer/core": {
-			"version": "11.2.1",
-			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
-			"integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@inquirer/ansi": "^2.0.7",
-				"@inquirer/figures": "^2.0.7",
-				"@inquirer/type": "^4.0.7",
-				"cli-width": "^4.1.0",
-				"fast-wrap-ansi": "^0.2.0",
-				"mute-stream": "^3.0.0",
-				"signal-exit": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
-			},
-			"peerDependencies": {
-				"@types/node": ">=18"
-			},
-			"peerDependenciesMeta": {
-				"@types/node": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/vitest/node_modules/@inquirer/figures": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
-			"integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
-			}
-		},
-		"node_modules/vitest/node_modules/@inquirer/type": {
-			"version": "4.0.7",
-			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
-			"integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
-			},
-			"peerDependencies": {
-				"@types/node": ">=18"
-			},
-			"peerDependenciesMeta": {
-				"@types/node": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/vitest/node_modules/@mswjs/interceptors": {
-			"version": "0.41.9",
-			"resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.9.tgz",
-			"integrity": "sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@open-draft/deferred-promise": "^2.2.0",
-				"@open-draft/logger": "^0.3.0",
-				"@open-draft/until": "^2.0.0",
-				"is-node-process": "^1.2.0",
-				"outvariant": "^1.4.3",
-				"strict-event-emitter": "^0.5.1"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@open-draft/until": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
-			"integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
-		},
 		"node_modules/vitest/node_modules/@vitest/expect": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.3.tgz",
@@ -16614,34 +15799,6 @@
 				"node": ">= 16"
 			}
 		},
-		"node_modules/vitest/node_modules/cli-width": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-			"integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">= 12"
-			}
-		},
-		"node_modules/vitest/node_modules/cookie": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-			"integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
 		"node_modules/vitest/node_modules/deep-eql": {
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -16662,93 +15819,12 @@
 				"@types/estree": "^1.0.0"
 			}
 		},
-		"node_modules/vitest/node_modules/headers-polyfill": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-5.0.1.tgz",
-			"integrity": "sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@types/set-cookie-parser": "^2.4.10",
-				"set-cookie-parser": "^3.0.1"
-			}
-		},
 		"node_modules/vitest/node_modules/loupe": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.2.tgz",
 			"integrity": "sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/vitest/node_modules/msw": {
-			"version": "2.15.0",
-			"resolved": "https://registry.npmjs.org/msw/-/msw-2.15.0.tgz",
-			"integrity": "sha512-2wQAmKkQKxRuXvYJxVhPGG0wZNBQyD06oJvxqw90XqLvptdqxdlHrFUfEteKkpaNORX3Xzc+HtEl/q0nfmN2wQ==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@inquirer/confirm": "^6.0.11",
-				"@mswjs/interceptors": "^0.41.3",
-				"@open-draft/deferred-promise": "^3.0.0",
-				"@types/statuses": "^2.0.6",
-				"cookie": "^1.1.1",
-				"graphql": "^16.13.2",
-				"headers-polyfill": "^5.0.1",
-				"is-node-process": "^1.2.0",
-				"outvariant": "^1.4.3",
-				"path-to-regexp": "^6.3.0",
-				"picocolors": "^1.1.1",
-				"rettime": "^0.11.11",
-				"statuses": "^2.0.2",
-				"strict-event-emitter": "^0.5.1",
-				"tough-cookie": "^6.0.1",
-				"type-fest": "^5.5.0",
-				"until-async": "^3.0.2",
-				"yargs": "^17.7.2"
-			},
-			"bin": {
-				"msw": "cli/index.js"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/mswjs"
-			},
-			"peerDependencies": {
-				"typescript": ">= 4.8.x"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/vitest/node_modules/msw/node_modules/@open-draft/deferred-promise": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-3.0.0.tgz",
-			"integrity": "sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/vitest/node_modules/mute-stream": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
-			"integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
 		},
 		"node_modules/vitest/node_modules/pathval": {
 			"version": "2.0.0",
@@ -16760,39 +15836,6 @@
 				"node": ">= 14.16"
 			}
 		},
-		"node_modules/vitest/node_modules/set-cookie-parser": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.2.tgz",
-			"integrity": "sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/vitest/node_modules/signal-exit": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/vitest/node_modules/strict-event-emitter": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
-			"integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
-		},
 		"node_modules/vitest/node_modules/tinyspy": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
@@ -16801,63 +15844,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/vitest/node_modules/tldts": {
-			"version": "7.4.9",
-			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
-			"integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"tldts-core": "^7.4.9"
-			},
-			"bin": {
-				"tldts": "bin/cli.js"
-			}
-		},
-		"node_modules/vitest/node_modules/tldts-core": {
-			"version": "7.4.9",
-			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
-			"integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/vitest/node_modules/tough-cookie": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
-			"integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"tldts": "^7.0.5"
-			},
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/vitest/node_modules/type-fest": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
-			"integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"tagged-tag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/w3c-keyname": {
@@ -17290,21 +16276,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/yoctocolors-cjs": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
-			"integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 	"dependencies": {
 		"@stomp/stompjs": "^7.0.0",
 		"@tanstack/react-query": "^5.29.0",
+		"@tanstack/react-virtual": "^3.14.9",
 		"@tiptap/extension-image": "^2.9.1",
 		"@tiptap/extension-text-align": "^2.9.1",
 		"@tiptap/extension-underline": "^2.9.1",

--- a/src/components/Chat/Chatting/Chatting.tsx
+++ b/src/components/Chat/Chatting/Chatting.tsx
@@ -2,7 +2,7 @@ import { useCallback, useRef, useState } from 'react';
 import ChatMessageActions from '@components/Chat/ChatMessageActions/ChatMessageActions';
 import LatestMessageBox from '@components/Chat/LatestMessageBox/LatestMessageBox';
 import MyMessageBox from '@components/Chat/MyMessageBox/MyMessageBox';
-import OtherMessageBox from '@components/Chat/OtherMessageBox/OtherMessageBox';
+import VirtualChatMessageList from '@components/Chat/VirtualChatMessageList/VirtualChatMessageList';
 import { Button } from '@components/common/Button/Button';
 import Flex from '@components/common/Flex/Flex';
 import IconButton from '@components/common/IconButton/IconButton';
@@ -13,13 +13,14 @@ import useChatMessages from '@hooks/chatting/useChatMessages';
 import useChatScroll from '@hooks/chatting/useChatScroll';
 import useChatSubscription from '@hooks/chatting/useChatSubscription';
 import useUserStatusQuery from '@hooks/queries/useUserStatusQuery';
-import { getFormattedDate } from '@utils/getFormattedDate';
 import * as S from './Chatting.styled';
 
 const Chatting = ({ selectedChat }: { selectedChat: number }) => {
 	const { userStatus } = useUserStatusQuery();
 	const chatRef = useRef<HTMLDivElement | null>(null);
+	const initializedVirtualLayoutChatIdRef = useRef<number | null>(null);
 	const [chatContainer, setChatContainer] = useState<HTMLDivElement | null>(null);
+	const [virtualLayoutReadyChatId, setVirtualLayoutReadyChatId] = useState<number | null>(null);
 
 	const {
 		chatHistory,
@@ -52,7 +53,7 @@ const Chatting = ({ selectedChat }: { selectedChat: number }) => {
 		chatContainer,
 		hasNextPage,
 		isFetchingNextPage,
-		isInitialScrollComplete,
+		isInitialScrollComplete: isInitialScrollComplete && virtualLayoutReadyChatId === selectedChat,
 		paginationVersion,
 		fetchNextPage,
 	});
@@ -86,6 +87,14 @@ const Chatting = ({ selectedChat }: { selectedChat: number }) => {
 
 		setChatContainer(element);
 	}, []);
+
+	const handleInitialVirtualLayoutSettled = useCallback(() => {
+		if (initializedVirtualLayoutChatIdRef.current === selectedChat) return;
+
+		initializedVirtualLayoutChatIdRef.current = selectedChat;
+		messageEndRef.current?.scrollIntoView();
+		setVirtualLayoutReadyChatId(selectedChat);
+	}, [messageEndRef, selectedChat]);
 
 	return (
 		<S.ChattingContainer>
@@ -141,84 +150,16 @@ const Chatting = ({ selectedChat }: { selectedChat: number }) => {
 							}
 						/>
 					))}
-					{chatHistory &&
-						chatHistory.chatChannelMessages.map((msg, index, array) => {
-							const previousMsg = index < array.length - 1 ? array[index + 1] : null;
-							const nextMsg = index > 0 ? array[index - 1] : null;
-
-							return (
-								<Flex direction='column' key={msg.id}>
-									{((previousMsg &&
-										getFormattedDate(msg.createdAt, 'chatDate') !==
-											getFormattedDate(previousMsg.createdAt, 'chatDate')) ||
-										index === array.length - 1) && (
-										<Flex justify='center' height='28' margin='20px 0 10px 0'>
-											<S.ChattingDateWrapper>
-												<Text size='sm' weight='medium' color='tertiary'>
-													{getFormattedDate(msg.createdAt, 'chatDate')}
-												</Text>
-											</S.ChattingDateWrapper>
-										</Flex>
-									)}
-									{msg.author.id === userStatus?.profile.userId ? (
-										<MyMessageBox
-											key={msg.id}
-											type={msg.type}
-											content={msg.content}
-											date={
-												nextMsg?.author.id !== msg.author.id ||
-												(nextMsg?.author.id === msg.author.id &&
-													nextMsg?.createdAt !== msg.createdAt)
-													? getFormattedDate(msg.createdAt, 'chatTime')
-													: null
-											}
-											file={
-												msg.attachments.length > 0
-													? msg.attachments.map((attachment) => ({
-															filename: attachment.filename,
-															url: attachment.url,
-															id: attachment.id,
-															size: attachment.size,
-														}))
-													: []
-											}
-											state={
-												previousMsg?.author.id !== msg.author.id ||
-												previousMsg?.createdAt !== msg.createdAt
-											}
-										/>
-									) : (
-										<OtherMessageBox
-											name={msg.author.username}
-											profile={msg.author.profileImageUrl}
-											type={msg.type}
-											content={msg.content}
-											date={
-												nextMsg?.author.id !== msg.author.id ||
-												(nextMsg?.author.id === msg.author.id &&
-													nextMsg?.createdAt !== msg.createdAt)
-													? getFormattedDate(msg.createdAt, 'chatTime')
-													: null
-											}
-											file={
-												msg.attachments.length > 0
-													? msg.attachments.map((attachment) => ({
-															filename: attachment.filename,
-															url: attachment.url,
-															id: attachment.id,
-															size: attachment.size,
-														}))
-													: []
-											}
-											state={
-												previousMsg?.author.id !== msg.author.id ||
-												previousMsg?.createdAt !== msg.createdAt
-											}
-										/>
-									)}
-								</Flex>
-							);
-						})}
+					{chatHistory && (
+						<VirtualChatMessageList
+							messages={chatHistory.chatChannelMessages}
+							chatContainer={chatContainer}
+							userId={userStatus?.profile.userId}
+							isInitialScrollComplete={isInitialScrollComplete}
+							isVirtualLayoutReady={virtualLayoutReadyChatId === selectedChat}
+							onInitialLayoutSettled={handleInitialVirtualLayoutSettled}
+						/>
+					)}
 					<S.ChatTopSentinel ref={topSentinelRef} />
 				</S.ChatMessageList>
 				<S.MessageEndWrapper ref={messageEndRef} />

--- a/src/components/Chat/Chatting/Chatting.tsx
+++ b/src/components/Chat/Chatting/Chatting.tsx
@@ -18,7 +18,6 @@ import * as S from './Chatting.styled';
 const Chatting = ({ selectedChat }: { selectedChat: number }) => {
 	const { userStatus } = useUserStatusQuery();
 	const chatRef = useRef<HTMLDivElement | null>(null);
-	const initializedVirtualLayoutChatIdRef = useRef<number | null>(null);
 	const [chatContainer, setChatContainer] = useState<HTMLDivElement | null>(null);
 	const [virtualLayoutReadyChatId, setVirtualLayoutReadyChatId] = useState<number | null>(null);
 
@@ -89,12 +88,11 @@ const Chatting = ({ selectedChat }: { selectedChat: number }) => {
 	}, []);
 
 	const handleInitialVirtualLayoutSettled = useCallback(() => {
-		if (initializedVirtualLayoutChatIdRef.current === selectedChat) return;
+		if (virtualLayoutReadyChatId === selectedChat) return;
 
-		initializedVirtualLayoutChatIdRef.current = selectedChat;
 		messageEndRef.current?.scrollIntoView();
 		setVirtualLayoutReadyChatId(selectedChat);
-	}, [messageEndRef, selectedChat]);
+	}, [messageEndRef, selectedChat, virtualLayoutReadyChatId]);
 
 	return (
 		<S.ChattingContainer>

--- a/src/components/Chat/VirtualChatMessageList/VirtualChatMessageList.tsx
+++ b/src/components/Chat/VirtualChatMessageList/VirtualChatMessageList.tsx
@@ -42,9 +42,12 @@ const VirtualChatMessageList = ({
 		overscan: 5,
 	});
 	const virtualItems = virtualizer.getVirtualItems();
+	const measuredItemKeys = new Set(
+		virtualizer.takeSnapshot().map((virtualItem) => virtualItem.key)
+	);
 	const hasMeasuredVirtualItems =
 		virtualItems.length > 0 &&
-		virtualItems.every((virtualItem) => virtualizer.itemSizeCache.has(virtualItem.key));
+		virtualItems.every((virtualItem) => measuredItemKeys.has(virtualItem.key));
 
 	useLayoutEffect(() => {
 		if (!hasMeasuredVirtualItems || hasNotifiedInitialLayoutRef.current) return;

--- a/src/components/Chat/VirtualChatMessageList/VirtualChatMessageList.tsx
+++ b/src/components/Chat/VirtualChatMessageList/VirtualChatMessageList.tsx
@@ -1,0 +1,126 @@
+import { useLayoutEffect, useMemo, useRef } from 'react';
+import * as S from '@components/Chat/Chatting/Chatting.styled';
+import MyMessageBox from '@components/Chat/MyMessageBox/MyMessageBox';
+import OtherMessageBox from '@components/Chat/OtherMessageBox/OtherMessageBox';
+import Flex from '@components/common/Flex/Flex';
+import Text from '@components/common/Text/Text';
+import VirtualList from '@components/common/VirtualList/VirtualList';
+import * as VirtualListStyle from '@components/common/VirtualList/VirtualList.styled';
+import useVirtualList from '@hooks/common/useVirtualList';
+import { getFormattedDate } from '@utils/getFormattedDate';
+import type { Message } from '@type/chat';
+
+const CHAT_MESSAGE_ESTIMATED_HEIGHT = 72;
+
+interface VirtualChatMessageListProps {
+	messages: Message[];
+	chatContainer: HTMLDivElement | null;
+	userId: number | undefined;
+	isInitialScrollComplete: boolean;
+	isVirtualLayoutReady: boolean;
+	onInitialLayoutSettled: () => void;
+}
+
+const VirtualChatMessageList = ({
+	messages,
+	chatContainer,
+	userId,
+	isInitialScrollComplete,
+	isVirtualLayoutReady,
+	onInitialLayoutSettled,
+}: VirtualChatMessageListProps) => {
+	const hasNotifiedInitialLayoutRef = useRef(false);
+	const chronologicalMessages = useMemo(() => [...messages].reverse(), [messages]);
+	const virtualizer = useVirtualList({
+		items: chronologicalMessages,
+		scrollElement: chatContainer,
+		getItemKey: (message) => message.id,
+		estimateSize: () => CHAT_MESSAGE_ESTIMATED_HEIGHT,
+		initialOffset: chronologicalMessages.length * CHAT_MESSAGE_ESTIMATED_HEIGHT,
+		enabled: isInitialScrollComplete,
+		useFlushSync: isVirtualLayoutReady,
+		overscan: 5,
+	});
+	const virtualItems = virtualizer.getVirtualItems();
+	const hasMeasuredVirtualItems =
+		virtualItems.length > 0 &&
+		virtualItems.every((virtualItem) => virtualizer.itemSizeCache.has(virtualItem.key));
+
+	useLayoutEffect(() => {
+		if (!hasMeasuredVirtualItems || hasNotifiedInitialLayoutRef.current) return;
+
+		hasNotifiedInitialLayoutRef.current = true;
+		onInitialLayoutSettled();
+	}, [hasMeasuredVirtualItems, onInitialLayoutSettled]);
+
+	if (!isInitialScrollComplete) {
+		return (
+			<VirtualListStyle.VirtualListContainer
+				style={{ height: chronologicalMessages.length * CHAT_MESSAGE_ESTIMATED_HEIGHT }}
+			/>
+		);
+	}
+
+	return (
+		<VirtualList
+			items={chronologicalMessages}
+			virtualizer={virtualizer}
+			renderItem={(message, index) => {
+				const previousMessage = index > 0 ? chronologicalMessages[index - 1] : null;
+				const nextMessage =
+					index < chronologicalMessages.length - 1 ? chronologicalMessages[index + 1] : null;
+				const isFirstMessageInGroup =
+					previousMessage?.author.id !== message.author.id ||
+					previousMessage?.createdAt !== message.createdAt;
+				const isLastMessageInGroup =
+					nextMessage?.author.id !== message.author.id ||
+					nextMessage?.createdAt !== message.createdAt;
+				const shouldShowDate =
+					!previousMessage ||
+					getFormattedDate(message.createdAt, 'chatDate') !==
+						getFormattedDate(previousMessage.createdAt, 'chatDate');
+				const attachments = message.attachments.map((attachment) => ({
+					filename: attachment.filename,
+					url: attachment.url,
+					id: attachment.id,
+					size: attachment.size,
+				}));
+
+				return (
+					<Flex direction='column'>
+						{shouldShowDate && (
+							<Flex justify='center' height='28' margin='20px 0 10px 0'>
+								<S.ChattingDateWrapper>
+									<Text size='sm' weight='medium' color='tertiary'>
+										{getFormattedDate(message.createdAt, 'chatDate')}
+									</Text>
+								</S.ChattingDateWrapper>
+							</Flex>
+						)}
+						{message.author.id === userId ? (
+							<MyMessageBox
+								type={message.type}
+								content={message.content}
+								date={isLastMessageInGroup ? getFormattedDate(message.createdAt, 'chatTime') : null}
+								file={attachments}
+								state={isFirstMessageInGroup}
+							/>
+						) : (
+							<OtherMessageBox
+								name={message.author.username}
+								profile={message.author.profileImageUrl}
+								type={message.type}
+								content={message.content}
+								date={isLastMessageInGroup ? getFormattedDate(message.createdAt, 'chatTime') : null}
+								file={attachments}
+								state={isFirstMessageInGroup}
+							/>
+						)}
+					</Flex>
+				);
+			}}
+		/>
+	);
+};
+
+export default VirtualChatMessageList;

--- a/src/components/Chat/VirtualChatMessageList/VirtualChatMessageList.tsx
+++ b/src/components/Chat/VirtualChatMessageList/VirtualChatMessageList.tsx
@@ -42,12 +42,14 @@ const VirtualChatMessageList = ({
 		overscan: 5,
 	});
 	const virtualItems = virtualizer.getVirtualItems();
-	const measuredItemKeys = new Set(
-		virtualizer.takeSnapshot().map((virtualItem) => virtualItem.key)
-	);
+	const isInitialLayoutPending = !hasNotifiedInitialLayoutRef.current;
+	const measuredItemKeys = isInitialLayoutPending
+		? new Set(virtualizer.takeSnapshot().map((virtualItem) => virtualItem.key))
+		: null;
 	const hasMeasuredVirtualItems =
+		isInitialLayoutPending &&
 		virtualItems.length > 0 &&
-		virtualItems.every((virtualItem) => measuredItemKeys.has(virtualItem.key));
+		virtualItems.every((virtualItem) => measuredItemKeys?.has(virtualItem.key));
 
 	useLayoutEffect(() => {
 		if (!hasMeasuredVirtualItems || hasNotifiedInitialLayoutRef.current) return;

--- a/src/components/common/Auth/AuthSessionManager.tsx
+++ b/src/components/common/Auth/AuthSessionManager.tsx
@@ -4,6 +4,7 @@ import { useErrorBoundary } from 'react-error-boundary';
 import { matchPath } from 'react-router-dom';
 import { clearClientSession } from '@apis/auth/sessionActions';
 import { restoreSession } from '@apis/auth/sessionRestore';
+import useSocketNetworkRecovery from '@hooks/socket/useSocketNetworkRecovery';
 import useAuthStore from '@stores/authStore';
 import useSocketStore from '@stores/socketStore';
 import { PATH } from '@constants/path';
@@ -66,6 +67,7 @@ const AuthSessionManager = ({ children }: AuthSessionManagerProps) => {
 	useRestoreSessionOnMount();
 	useSyncSessionAcrossTabs();
 	useSyncSocketWithAuthStatus(status);
+	useSocketNetworkRecovery();
 
 	return children;
 };

--- a/src/components/common/VirtualList/VirtualList.styled.ts
+++ b/src/components/common/VirtualList/VirtualList.styled.ts
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+export const VirtualListContainer = styled.div`
+	position: relative;
+`;
+
+export const VirtualItem = styled.div`
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+`;

--- a/src/components/common/VirtualList/VirtualList.tsx
+++ b/src/components/common/VirtualList/VirtualList.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from 'react';
+import type { Virtualizer } from '@tanstack/react-virtual';
+import * as S from './VirtualList.styled';
+
+interface VirtualListProps<T> {
+	items: T[];
+	virtualizer: Virtualizer<HTMLDivElement, Element>;
+	renderItem: (item: T, index: number) => ReactNode;
+}
+
+const VirtualList = <T,>({ items, virtualizer, renderItem }: VirtualListProps<T>) => {
+	return (
+		<S.VirtualListContainer style={{ height: virtualizer.getTotalSize() }}>
+			{virtualizer.getVirtualItems().map((virtualItem) => (
+				<S.VirtualItem
+					key={virtualItem.key}
+					data-index={virtualItem.index}
+					ref={virtualizer.measureElement}
+					style={{ transform: `translateY(${virtualItem.start}px)` }}>
+					{renderItem(items[virtualItem.index], virtualItem.index)}
+				</S.VirtualItem>
+			))}
+		</S.VirtualListContainer>
+	);
+};
+
+export default VirtualList;

--- a/src/hooks/common/useVirtualList.ts
+++ b/src/hooks/common/useVirtualList.ts
@@ -1,0 +1,36 @@
+import { useVirtualizer } from '@tanstack/react-virtual';
+
+interface UseVirtualListProps<T> {
+	items: T[];
+	scrollElement: HTMLDivElement | null;
+	getItemKey: (item: T) => string | number;
+	estimateSize: (index: number) => number;
+	initialOffset?: number;
+	enabled?: boolean;
+	useFlushSync?: boolean;
+	overscan?: number;
+}
+
+const useVirtualList = <T>({
+	items,
+	scrollElement,
+	getItemKey,
+	estimateSize,
+	initialOffset,
+	enabled = true,
+	useFlushSync = true,
+	overscan = 5,
+}: UseVirtualListProps<T>) => {
+	return useVirtualizer({
+		count: items.length,
+		getScrollElement: () => scrollElement,
+		getItemKey: (index) => getItemKey(items[index]),
+		estimateSize,
+		initialOffset,
+		enabled,
+		useFlushSync,
+		overscan,
+	});
+};
+
+export default useVirtualList;


### PR DESCRIPTION
## 📌 관련 이슈

- #219

## ✨ PR 세부 내용

채팅 메시지 수가 많아질 때 전체 메시지 컴포넌트를 한 번에 렌더링하던 구조를 가상 스크롤 방식으로 전환했습니다. 또한 브라우저 네트워크가 복구되었을 때 재연결 대기 중인 소켓이 다시 연결되도록 앱의 인증·세션 관리 흐름에 복구 훅을 등록했습니다.

### 채팅 메시지 가상 스크롤

- `@tanstack/react-virtual` 의존성을 추가했습니다.
- 재사용 가능한 `useVirtualList`, `VirtualList`를 추가했습니다.
- 채팅 메시지 렌더링을 `VirtualChatMessageList`로 분리하고, 뷰포트에 필요한 메시지만 렌더링하도록 변경했습니다.
- 실제 메시지 높이를 측정해 이미지·파일 등 가변 높이 메시지에서도 목록 위치를 보정합니다.
- 초기 레이아웃 측정이 끝난 뒤 채팅 하단으로 이동하도록 처리해 최초 진입 시 스크롤 위치를 유지합니다.
- 날짜 구분과 발신자별 메시지 그룹 표시 규칙은 기존 동작을 유지합니다.

### 네트워크 복구 시 소켓 재연결 등록

- `AuthSessionManager`에서 네트워크 복구 훅을 등록했습니다.
- 브라우저 네트워크가 복구되면 `reconnectWaiting` 상태와 자동 복구 제한 시간이 만료된 `disconnected` 상태에서 소켓 재연결을 요청합니다.
- 로그아웃 또는 명시적 연결 해제 후에는 소켓 클라이언트와 토큰이 초기화되므로, `online` 이벤트가 발생해도 재연결 요청은 실행되지 않습니다.

## 📸 스크린샷
가상 스크롤 도입 전

https://github.com/user-attachments/assets/92edd1aa-b89d-4c45-982c-aab205ac573b

가상 스크롤 도입 후

https://github.com/user-attachments/assets/8c078d53-123d-4a8c-82c1-f39de2155de5


## ✅ 리뷰 요구사항

- 최초 채팅방 진입과 이전 메시지 로드 시 스크롤 위치가 의도대로 하단 또는 기존 위치에 유지되는지 확인 부탁드립니다.
- 이미지·파일 메시지처럼 높이가 다른 항목에서도 가상 목록의 위치 계산과 날짜·메시지 그룹 표시가 정상인지 확인 부탁드립니다.
- 네트워크 복구 이벤트가 재연결 대기 상태에서만 소켓 재연결을 요청하는지 확인 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 대화 메시지에 가상 스크롤을 적용해 많은 메시지도 더 효율적으로 표시합니다.
  - 메시지 높이와 초기 위치를 자동으로 계산하고, 대화 시작 시 최신 메시지로 이동합니다.
  - 공통 가상 목록 기능을 추가해 목록 렌더링 성능과 화면 반응성을 개선했습니다.

- **개선**
  - 네트워크 복구 시 채팅 연결이 보다 안정적으로 재개됩니다.
  - 날짜 구분, 첨부파일, 발신자별 메시지 표시 등 기존 채팅 기능을 유지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->