### PR TITLE
styled-components 스타일 전용 prop DOM 전달 방지

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,9 @@
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<link
+			rel="stylesheet"
+			href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css" />
 		<script>
 			var global = window;
 		</script>

--- a/src/components/common/Divider/Divider.styled.ts
+++ b/src/components/common/Divider/Divider.styled.ts
@@ -9,12 +9,11 @@ const dividerSizeMap = {
 	sm: '1px',
 };
 
-export const DividerContainer = styled.div<Omit<DividerProps, 'size'>>`
-	padding: ${(props) => (props.padding ? `${props.padding}px 0` : '0')};
+export const DividerContainer = styled.div<{ $padding?: number }>`
+	padding: ${({ $padding }) => ($padding ? `${$padding}px 0` : '0')};
 `;
 
 export const DividerWrapper = styled.div<DividerProps>`
-	border-bottom: ${(props) => dividerSizeMap[props.size]} solid
-		${theme.color.border.tertiary};
+	border-bottom: ${(props) => dividerSizeMap[props.size]} solid ${theme.color.border.tertiary};
 	height: ${(props) => dividerSizeMap[props.size]};
 `;

--- a/src/components/common/Divider/Divider.tsx
+++ b/src/components/common/Divider/Divider.tsx
@@ -9,7 +9,7 @@ export interface DividerProps {
 const Divider = (props: DividerProps) => {
 	const { size, padding } = props;
 	return (
-		<S.DividerContainer padding={padding}>
+		<S.DividerContainer $padding={padding}>
 			<S.DividerWrapper size={size} />
 		</S.DividerContainer>
 	);

--- a/src/components/common/Flex/Flex.styled.ts
+++ b/src/components/common/Flex/Flex.styled.ts
@@ -1,5 +1,30 @@
 import styled from 'styled-components';
 
+const FLEX_STYLE_PROPS = [
+	'direction',
+	'wrap',
+	'basis',
+	'grow',
+	'shrink',
+	'align',
+	'justify',
+	'gap',
+	'margin',
+	'marginRight',
+	'marginTop',
+	'marginLeft',
+	'marginBottom',
+	'padding',
+	'paddingTop',
+	'paddingRight',
+	'paddingBottom',
+	'paddingLeft',
+	'border',
+	'width',
+	'height',
+	'position',
+] as const;
+
 export interface FlexStyleProps {
 	direction?: 'row' | 'column';
 	wrap?: 'nowrap' | 'wrap' | 'wrap-reverse';
@@ -55,7 +80,8 @@ export interface FlexStyleProps {
 }
 
 export const FlexWrapper = styled.div.withConfig({
-	shouldForwardProp: (prop) => !['gap', 'align'].includes(prop),
+	shouldForwardProp: (prop) =>
+		!FLEX_STYLE_PROPS.includes(prop as (typeof FLEX_STYLE_PROPS)[number]),
 })<FlexStyleProps>`
 	display: flex;
 	flex-direction: ${({ direction }) => direction || 'row'};

--- a/src/components/common/GNB/GNBMenu/GNBTeamInfo/GNBTeamInfo.styled.ts
+++ b/src/components/common/GNB/GNBMenu/GNBTeamInfo/GNBTeamInfo.styled.ts
@@ -40,7 +40,7 @@ export const TeamSpaceUserContainer = styled.div`
 	}
 `;
 
-export const InputWrapper = styled.form`
+export const InputWrapper = styled.div`
 	display: flex;
 	width: 216px;
 

--- a/src/components/common/Toast/Toast.styled.ts
+++ b/src/components/common/Toast/Toast.styled.ts
@@ -1,10 +1,7 @@
 import styled from 'styled-components';
 import { fadeIn, fadeOut } from '@styles/animations';
-import type { ToastProps } from './Toast';
 
-type toastWrapperProps = Pick<ToastProps, 'isActive'>;
-
-export const ToastWrapper = styled.div<toastWrapperProps>`
+export const ToastWrapper = styled.div<{ $isActive: boolean }>`
 	display: flex;
 	justify-content: center;
 	align-items: center;
@@ -18,7 +15,7 @@ export const ToastWrapper = styled.div<toastWrapperProps>`
 	-webkit-backdrop-filter: blur(8px);
 	border-radius: ${(props) => props.theme.units.radius.radius12};
 	box-shadow: ${(props) => props.theme.elevation.shadow.shadow8};
-	animation: ${(props) => (props.isActive ? fadeIn : fadeOut)} 0.4s ease-out;
+	animation: ${({ $isActive }) => ($isActive ? fadeIn : fadeOut)} 0.4s ease-out;
 `;
 
 export const ToastTextWrapper = styled.div`

--- a/src/components/common/Toast/Toast.tsx
+++ b/src/components/common/Toast/Toast.tsx
@@ -28,7 +28,7 @@ const Toast = (props: ToastProps) => {
 	}, [id, isActive, removeToast]);
 
 	return createPortal(
-		<S.ToastWrapper ref={ref} isActive={isActive}>
+		<S.ToastWrapper ref={ref} $isActive={isActive}>
 			<Icon name={variant} size='lg' />
 			<S.ToastTextWrapper>
 				<Text as='span' color='iInverse' size='lg' weight='medium'>

--- a/src/hooks/common/useMenu.tsx
+++ b/src/hooks/common/useMenu.tsx
@@ -9,12 +9,19 @@ interface MenuPosition {
 	right?: number;
 }
 
-const MenuContainer = styled.div<MenuPosition>`
+interface MenuContainerProps {
+	$top?: number;
+	$bottom?: number;
+	$left?: number;
+	$right?: number;
+}
+
+const MenuContainer = styled.div<MenuContainerProps>`
 	position: absolute;
-	top: ${(props) => `${props.top}px` ?? 'auto'};
-	bottom: ${(props) => `${props.bottom}px` ?? 'auto'};
-	left: ${(props) => `${props.left}px` ?? 'auto'};
-	right: ${(props) => `${props.right}px` ?? 'auto'};
+	top: ${({ $top }) => ($top === undefined ? 'auto' : `${$top}px`)};
+	bottom: ${({ $bottom }) => ($bottom === undefined ? 'auto' : `${$bottom}px`)};
+	left: ${({ $left }) => ($left === undefined ? 'auto' : `${$left}px`)};
+	right: ${({ $right }) => ($right === undefined ? 'auto' : `${$right}px`)};
 	z-index: ${(props) => props.theme.elevation.zIndex.MENU};
 `;
 
@@ -49,7 +56,12 @@ const useMenu = () => {
 
 		return (
 			isVisible && (
-				<MenuContainer ref={ref} {...position}>
+				<MenuContainer
+					ref={ref}
+					$top={position.top}
+					$bottom={position.bottom}
+					$left={position.left}
+					$right={position.right}>
 					{menu}
 				</MenuContainer>
 			)

--- a/src/pages/SettingPage/SettingPage.tsx
+++ b/src/pages/SettingPage/SettingPage.tsx
@@ -279,6 +279,7 @@ const SettingPage = () => {
 							<S.TeamMemberContainer>
 								{teamSetting.users.map((user, index) => (
 									<TeamMemberItem
+										key={user.id}
 										profile={user.profileImageUrl}
 										username={user.username}
 										email={user.email}

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -3,7 +3,6 @@ import reset from 'styled-reset';
 import { GNB_HEIGHT } from '@styles/layout';
 
 const GlobalStyle = createGlobalStyle`
-  @import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css");
   ${reset}
 
   #root {


### PR DESCRIPTION
## 📌 관련 이슈

- #235

## ✨ PR 세부 내용

styled-components의 스타일 전용 prop이 DOM 요소까지 전달되어 발생하던 React 콘솔 경고를 정리했습니다. 공통 `Flex`를 중심으로 prop 전달 기준을 보완하고, 개별 컴포넌트에서 사용하는 스타일 전용 prop도 transient prop으로 전환했습니다.

### 공통 `Flex` 스타일 prop 전달 차단

- `Flex`의 레이아웃·간격·크기·정렬 관련 스타일 prop 목록을 `FLEX_STYLE_PROPS`로 단일 관리합니다.
- `shouldForwardProp`에서 해당 목록 전체를 차단해 `paddingLeft`, `paddingRight` 등의 prop이 DOM 속성으로 전달되지 않도록 수정했습니다.
- 기존 `Flex` 호출부의 prop 이름은 유지해 레이아웃 사용 방식은 변경하지 않았습니다.

### 개별 styled-components prop 정리

- `Divider`의 `padding`, `Toast`의 활성 상태, 메뉴 위치 값은 transient prop으로 전환했습니다.
- 메뉴 위치 값이 없을 때 `undefinedpx`가 아닌 `auto`가 적용되도록 처리했습니다.
- 팀스페이스 정보 영역의 중첩 `form` 구조를 `div`로 변경했습니다.

### 기타 정리

- 팀원 목록 항목에 안정적인 React `key`를 추가했습니다.
- Pretendard 스타일시트 로드를 전역 스타일의 `@import`에서 문서 head의 `<link>`로 이동했습니다.

## ✅ 리뷰 요구사항

- `Flex`의 스타일 prop 전체가 DOM으로 전달되지 않으면서 기존 레이아웃이 유지되는지 확인 부탁드립니다.
- `Divider`, `Toast`, 메뉴 위치 값 변경 후 콘솔 경고 없이 기존 표시·동작이 유지되는지 확인 부탁드립니다.
- 팀스페이스 정보 영역에서 입력·초대 관련 동작이 기존과 동일한지 확인 부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * Pretendard 가변 웹폰트를 적용해 전반적인 글꼴 표시를 개선했습니다.

* **버그 수정**
  * 메뉴 위치와 토스트 알림 표시가 더욱 안정적으로 동작하도록 개선했습니다.
  * 설정 화면의 팀원 목록 렌더링 안정성을 높였습니다.

* **개선**
  * 구분선과 레이아웃 요소의 스타일 처리를 정리해 불필요한 속성 전달을 방지했습니다.
  * 팀 정보 입력 영역의 동작 안정성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->